### PR TITLE
Expand 1-degree logic to include parents' spouses and children's parents

### DIFF
--- a/src/components/modals/BulkInviteModal.tsx
+++ b/src/components/modals/BulkInviteModal.tsx
@@ -74,6 +74,33 @@ export default function BulkInviteModal({
           }).map((l: any) => typeof l.source === 'object' ? l.source.id : l.source);
           
           if (userParents.some(p => theirParents.includes(p))) relationship = 'Sibling';
+          else {
+            // Parent's Spouse check (Step-parent or other biological parent)
+            const isParentsSpouse = userParents.some(parentId => 
+              linksCopy.some((l: any) => {
+                const s = typeof l.source === 'object' ? l.source.id : l.source;
+                const t = typeof l.target === 'object' ? l.target.id : l.target;
+                return l.type === 'marriage' && ((s === parentId && t === nodeId) || (t === parentId && s === nodeId));
+              })
+            );
+            if (isParentsSpouse) relationship = 'Parent';
+            else {
+              // Child's other parent check
+              const userChildren = linksCopy.filter((l: any) => {
+                const s = typeof l.source === 'object' ? l.source.id : l.source;
+                return s === userNodeId && l.type === 'parent';
+              }).map((l: any) => typeof l.target === 'object' ? l.target.id : l.target);
+
+              const isChildsParent = userChildren.some(childId => 
+                linksCopy.some((l: any) => {
+                  const s = typeof l.source === 'object' ? l.source.id : l.source;
+                  const t = typeof l.target === 'object' ? l.target.id : l.target;
+                  return l.type === 'parent' && t === childId && s === nodeId;
+                })
+              );
+              if (isChildsParent) relationship = 'Spouse';
+            }
+          }
         }
 
         return { node, relationship, existingInvites: 0, selected: false };

--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -158,6 +158,28 @@ export function isWithin1Degree(
 
   if (sharesParent) return true;
 
+  // NEW: Check for parent's spouse (e.g. mother if I'm linked to father)
+  const isParentsSpouse = userParents.some(parentId => 
+    links.some((link: any) => {
+      const s = getSafeId(link.source);
+      const t = getSafeId(link.target);
+      return link.type === 'marriage' && 
+             ((s === parentId && t === targetNodeId) || (t === parentId && s === targetNodeId));
+    })
+  );
+  if (isParentsSpouse) return true;
+
+  // NEW: Check for child's parent (e.g. spouse who isn't explicitly linked to me but is linked to my child)
+  const userChildren = getChildren(userNodeId, links);
+  const isChildsParent = userChildren.some(childId => 
+    links.some((link: any) => {
+      const s = getSafeId(link.source);
+      const t = getSafeId(link.target);
+      return link.type === 'parent' && t === childId && s === targetNodeId;
+    })
+  );
+  if (isChildsParent) return true;
+
   return false;
 }
 
@@ -224,6 +246,22 @@ export async function getNodeRelationship(
     const targetParents = getParents(targetNodeId, familyLinks);
     if (userParents.some(p => targetParents.includes(p))) return { type: 'sibling', label: 'Sibling' };
 
+    // Parent's spouse
+    const isParentsSpouse = userParents.some(parentId => 
+      familyLinks.some(link => 
+        link.type === 'marriage' && 
+        ((link.source === parentId && link.target === targetNodeId) || (link.target === parentId && link.source === targetNodeId))
+      )
+    );
+    if (isParentsSpouse) return { type: 'parent', label: 'Parent' };
+
+    // Child's other parent
+    const userChildren = getChildren(userNodeId, familyLinks);
+    const isChildsOtherParent = userChildren.some(childId => 
+      familyLinks.some(link => link.type === 'parent' && link.target === childId && link.source === targetNodeId)
+    );
+    if (isChildsOtherParent) return { type: 'spouse', label: 'Spouse' };
+
     return { type: 'unrelated', label: 'Not 1-degree' };
   } catch (err) {
     return { type: 'unrelated', label: 'Error' };
@@ -251,8 +289,31 @@ export function get1DegreeNodesSync(
 
   const userParents = getParents(userNodeId, links);
   userParents.forEach(parentId => {
+    // Siblings
     const siblings = getChildren(parentId, links).filter(id => id !== userNodeId);
     siblings.forEach(id => oneDegreeIds.add(id));
+    
+    // Parent's spouse
+    links.forEach((link: any) => {
+      if (link.type === 'marriage') {
+        const s = getSafeId(link.source);
+        const t = getSafeId(link.target);
+        if (s === parentId && t) oneDegreeIds.add(t);
+        else if (t === parentId && s) oneDegreeIds.add(s);
+      }
+    });
+  });
+
+  // NEW: Child's other parent
+  const userChildren = getChildren(userNodeId, links);
+  userChildren.forEach(childId => {
+    links.forEach((link: any) => {
+      if (link.type === 'parent') {
+        const s = getSafeId(link.source);
+        const t = getSafeId(link.target);
+        if (t === childId && s && s !== userNodeId) oneDegreeIds.add(s);
+      }
+    });
   });
 
   return Array.from(oneDegreeIds);


### PR DESCRIPTION
This update allows users to invite and manage family members who were technically two links away but biologically 1-degree, such as a mother linked via a father's marriage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands access-control/relationship logic used for editing and invite management, which could unintentionally broaden who is considered within a user’s 1-degree network if the underlying link data is inconsistent.
> 
> **Overview**
> Expands the definition of a user’s **1-degree network** to include *a parent’s spouse* (e.g., step-parent/other biological parent connected via `marriage`) and *a child’s other parent* (connected via the child’s `parent` links), not just direct links and siblings.
> 
> Updates `isWithin1Degree`, `get1DegreeNodesSync`, and `getNodeRelationship` in `permissions.ts` accordingly, and adjusts `BulkInviteModal` to label these newly-included relatives as `Parent` or `Spouse` when generating the invite list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 033a43d658165f97d46dd4aad87aaa6f0fcade00. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->