### PR TITLE
Spheres now default skin, instead of planets

### DIFF
--- a/src/components/FamilyTree3D.tsx
+++ b/src/components/FamilyTree3D.tsx
@@ -176,7 +176,7 @@ const FamilyTree3D: React.FC = () => {
 
   // V3 Features: Toggles and Collapsed state
   const [showNames, setShowNames] = useState(true);
-  const [nodeTexture, setNodeTexture] = useState<'spheres' | 'planets' | 'none'>('planets');
+  const [nodeTexture, setNodeTexture] = useState<'spheres' | 'planets' | 'none'>('spheres');
   const [showArrows, setShowArrows] = useState(false);
   const [collapsedNodes, setCollapsedNodes] = useState<Set<string>>(new Set());
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single UI default-value change with no data, auth, or behavioral logic impact beyond initial rendering style.
> 
> **Overview**
> Updates `FamilyTree3D` so the default `nodeTexture` changes from `planets` to **`spheres`**, altering the initial visual style until the user selects a different texture mode.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4edcc05c5f724c558c7fdb9ef963ced857ea712. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->