### PR TITLE
X Individuals and Y Families counter now fixed

### DIFF
--- a/src/hooks/usePublicMetrics.ts
+++ b/src/hooks/usePublicMetrics.ts
@@ -7,22 +7,96 @@ interface PublicMetrics {
   hasError: boolean;
 }
 
+const CACHE_KEY = 'family_tree_metrics';
+const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
+
+interface CachedMetrics {
+  individuals: number;
+  families: number;
+  timestamp: number;
+}
+
+function getCachedMetrics(): CachedMetrics | null {
+  try {
+    const cached = localStorage.getItem(CACHE_KEY);
+    if (!cached) return null;
+    
+    const data: CachedMetrics = JSON.parse(cached);
+    const now = Date.now();
+    
+    // Check if cache is still valid
+    if (now - data.timestamp < CACHE_TTL) {
+      return data;
+    }
+    
+    // Cache expired, remove it
+    localStorage.removeItem(CACHE_KEY);
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function setCachedMetrics(individuals: number, families: number) {
+  try {
+    const data: CachedMetrics = {
+      individuals,
+      families,
+      timestamp: Date.now(),
+    };
+    localStorage.setItem(CACHE_KEY, JSON.stringify(data));
+  } catch {
+    // Ignore localStorage errors
+  }
+}
+
 export function usePublicMetrics(): PublicMetrics {
-  const [metrics, setMetrics] = useState<PublicMetrics>({
-    individuals: 0,
-    families: 0,
-    isLoading: true,
-    hasError: false,
+  const [metrics, setMetrics] = useState<PublicMetrics>(() => {
+    // Try to load from cache immediately
+    const cached = getCachedMetrics();
+    if (cached) {
+      return {
+        individuals: cached.individuals,
+        families: cached.families,
+        isLoading: false,
+        hasError: false,
+      };
+    }
+    
+    return {
+      individuals: 0,
+      families: 0,
+      isLoading: true,
+      hasError: false,
+    };
   });
 
   useEffect(() => {
+    // Check cache first
+    const cached = getCachedMetrics();
+    if (cached) {
+      setMetrics({
+        individuals: cached.individuals,
+        families: cached.families,
+        isLoading: false,
+        hasError: false,
+      });
+      return;
+    }
+
     const fetchMetrics = async () => {
       try {
         const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
         const supabaseKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
+        console.log('[usePublicMetrics] Starting fetch...', { 
+          hasUrl: !!supabaseUrl, 
+          hasKey: !!supabaseKey,
+          url: supabaseUrl?.substring(0, 30) + '...'
+        });
+
         if (!supabaseUrl || !supabaseKey) {
-          // Hide component if env vars not set
+          console.warn('[usePublicMetrics] Missing env vars');
           setMetrics({
             individuals: 0,
             families: 0,
@@ -32,48 +106,46 @@ export function usePublicMetrics(): PublicMetrics {
           return;
         }
 
-        // Fetch node count (individuals)
-        const nodesResponse = await fetch(
-          `${supabaseUrl}/rest/v1/nodes?select=id`,
-          {
-            method: 'GET',
-            headers: {
-              'apikey': supabaseKey,
-              'Authorization': `Bearer ${supabaseKey}`,
-            },
-          }
-        );
+        // Call public RPC function (bypasses RLS)
+        const rpcUrl = `${supabaseUrl}/rest/v1/rpc/get_public_metrics`;
+        console.log('[usePublicMetrics] Calling RPC:', rpcUrl);
+        
+        const rpcResponse = await fetch(rpcUrl, {
+          method: 'POST',
+          headers: {
+            'apikey': supabaseKey,
+            'Authorization': `Bearer ${supabaseKey}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({}),
+        });
 
-        if (!nodesResponse.ok) {
-          throw new Error('Failed to fetch node count');
+        console.log('[usePublicMetrics] RPC response status:', rpcResponse.status, rpcResponse.statusText);
+
+        if (!rpcResponse.ok) {
+          const errorText = await rpcResponse.text();
+          console.error('[usePublicMetrics] RPC call failed:', {
+            status: rpcResponse.status,
+            statusText: rpcResponse.statusText,
+            error: errorText,
+          });
+          
+          throw new Error(`Failed to fetch metrics: ${rpcResponse.status} ${rpcResponse.statusText}`);
         }
 
-        const nodes = await nodesResponse.json();
-        const individualCount = nodes?.length || 0;
+        const metricsData = await rpcResponse.json();
+        console.log('[usePublicMetrics] RPC response:', metricsData);
 
-        // Fetch unique family clusters (families)
-        const clustersResponse = await fetch(
-          `${supabaseUrl}/rest/v1/nodes?select=family_cluster`,
-          {
-            method: 'GET',
-            headers: {
-              'apikey': supabaseKey,
-              'Authorization': `Bearer ${supabaseKey}`,
-            },
-          }
-        );
+        const individualCount = metricsData?.individuals || 0;
+        const familyCount = metricsData?.families || 0;
 
-        if (!clustersResponse.ok) {
-          throw new Error('Failed to fetch family clusters');
-        }
+        console.log('[usePublicMetrics] Calculated metrics:', { 
+          individualCount, 
+          familyCount
+        });
 
-        const clusterData = await clustersResponse.json();
-        const uniqueFamilies = new Set(
-          clusterData
-            ?.map((n: any) => n.family_cluster)
-            .filter((c: string | null) => c && c.trim() !== '')
-        );
-        const familyCount = uniqueFamilies.size;
+        // Cache the results
+        setCachedMetrics(individualCount, familyCount);
 
         setMetrics({
           individuals: individualCount,
@@ -82,8 +154,13 @@ export function usePublicMetrics(): PublicMetrics {
           hasError: false,
         });
       } catch (err) {
-        console.error('[usePublicMetrics] Error:', err);
-        // Hide component on error
+        console.error('[usePublicMetrics] Exception caught:', err);
+        if (err instanceof Error) {
+          console.error('[usePublicMetrics] Error details:', {
+            message: err.message,
+            stack: err.stack
+          });
+        }
         setMetrics({
           individuals: 0,
           families: 0,

--- a/supabase-public-metrics.sql
+++ b/supabase-public-metrics.sql
@@ -1,0 +1,36 @@
+-- ============================================================================
+-- PUBLIC METRICS RPC FUNCTION
+-- ============================================================================
+-- This function allows unauthenticated access to tree statistics
+-- for the landing page. It bypasses RLS by using SECURITY DEFINER.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION get_public_metrics()
+RETURNS JSON
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  individual_count INTEGER;
+  family_count INTEGER;
+BEGIN
+  -- Count total nodes (individuals)
+  SELECT COUNT(*) INTO individual_count
+  FROM nodes;
+
+  -- Count unique family clusters (families)
+  SELECT COUNT(DISTINCT family_cluster) INTO family_count
+  FROM nodes
+  WHERE family_cluster IS NOT NULL AND family_cluster != '';
+
+  -- Return as JSON
+  RETURN json_build_object(
+    'individuals', individual_count,
+    'families', family_count
+  );
+END;
+$$;
+
+-- Grant execute permission to anon role (public access)
+GRANT EXECUTE ON FUNCTION get_public_metrics() TO anon;


### PR DESCRIPTION
Uses RPC to bypass Supabase RLS, and caches to localStorage for 5min for fast reload