### PR TITLE
chore(db): explicit Data API grants for public tables

### DIFF
--- a/supabase/SCHEMA_NOTES.md
+++ b/supabase/SCHEMA_NOTES.md
@@ -29,7 +29,20 @@ Users can view and edit only their **1-degree network**:
 
 ### Audit log
 
-`audit_log` has RLS disabled (empty table, no policies). Re-enable and add policies if you implement audit logging.
+`audit_log` has RLS disabled (empty table, no policies). Re-enable and add policies if you implement audit logging. Migration `20260514120000_data_api_public_table_grants.sql` revokes `anon`/`authenticated` on this table (to drop legacy defaults) and grants DML only to `service_role` for PostgREST. Do not extend `anon`/`authenticated` here without enabling RLS and policies first.
+
+### Data API: grants on `public` tables
+
+Supabase applies **Postgres `GRANT`s** plus **RLS policies** together: the JWT role must hold the privilege **and** any policy must allow the row. New projects no longer infer table grants automatically; migrations must declare them—see migration `20260514120000_data_api_public_table_grants.sql`.
+
+**Convention for new tables**
+
+1. `CREATE TABLE` in `public`.
+2. Enable RLS and add policies (`TO authenticated`, `TO public`, etc.) as usual.
+3. In the **same migration** (or immediately after table creation): `GRANT` the appropriate verbs on that table to `anon`, `authenticated`, and/or `service_role` for how you intend PostgREST / `supabase-js` to use it. Omit `anon`/`authenticated` when RLS is off or when only the service role should access the table.
+4. Add `USAGE, SELECT ON SEQUENCES` for that table only if it uses `serial`, identity, or other sequences.
+
+If a grant is missing, PostgREST returns `42501` with a suggested `GRANT` in the error detail.
 
 ## Using another Postgres provider
 

--- a/supabase/migrations/20260514120000_data_api_public_table_grants.sql
+++ b/supabase/migrations/20260514120000_data_api_public_table_grants.sql
@@ -1,0 +1,23 @@
+-- -----------------------------------------------------------------------------
+-- Data API (PostgREST / supabase-js): explicit privileges on public tables
+-- -----------------------------------------------------------------------------
+-- Required for Supabase projects where new public tables are not auto-exposed to
+-- the Data API (default for new projects from 2026-05-30; enforced for existing
+-- projects for tables created after 2026-10-30). See:
+-- https://github.com/orgs/supabase/discussions/45329
+--
+-- RLS continues to constrain anon/authenticated; service_role bypasses RLS.
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.users TO anon, authenticated,
+  service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.nodes TO anon, authenticated,
+  service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.links TO anon, authenticated,
+  service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.node_invites TO anon, authenticated,
+  service_role;
+
+-- RLS disabled on audit_log — do not grant anon/authenticated (would expose rows via REST).
+-- Revoke default-era privileges on existing projects; then allow only service_role for REST.
+REVOKE ALL ON TABLE public.audit_log FROM anon, authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.audit_log TO service_role;


### PR DESCRIPTION
- Add migration granting SELECT/INSERT/UPDATE/DELETE to anon, authenticated, and service_role for RLS-backed app tables.

- Restrict audit_log to service_role only; RLS is disabled on that table.

- Document the convention in supabase/SCHEMA_NOTES.md for future migrations.