### PR TITLE
fix(search): keep search nav arrows clickable above detail drawer

### DIFF
--- a/src/components/FamilyTree2D.tsx
+++ b/src/components/FamilyTree2D.tsx
@@ -535,7 +535,7 @@ export const FamilyTree2D: React.FC<FamilyTree2DProps> = ({
         display: 'flex',
         flexDirection: 'column',
         gap: '12px',
-        zIndex: 1000,
+        zIndex: 1300,
         alignItems: 'flex-end',
       }}>
         {/* Settings Toggle - First */}

--- a/src/components/FamilyTree3D.tsx
+++ b/src/components/FamilyTree3D.tsx
@@ -1346,7 +1346,7 @@ export const FamilyTree3DContent: React.FC<FamilyTree3DProps> = ({
       />
 
       {/* Settings Controls - Top Right */}
-      <div style={{ position: 'absolute', top: '24px', right: '24px', display: 'flex', flexDirection: 'column', gap: '12px', zIndex: 1000, alignItems: 'flex-end' }}>
+      <div style={{ position: 'absolute', top: '24px', right: '24px', display: 'flex', flexDirection: 'column', gap: '12px', zIndex: 1300, alignItems: 'flex-end' }}>
         {/* Settings Toggle - First */}
         <Button
           variant="contained"

--- a/src/components/PersonDetailDrawer.tsx
+++ b/src/components/PersonDetailDrawer.tsx
@@ -198,13 +198,6 @@ export const PersonDetailDrawer: React.FC<PersonDetailDrawerProps> = ({
           )}
         </Box>
       </Box>
-
-      {/* Footer / Archive Note */}
-      <Box sx={{ p: 3, borderTop: '1px solid rgba(255,255,255,0.05)', background: 'rgba(0,0,0,0.2)' }}>
-        <Typography variant="body2" sx={{ color: 'rgba(255,255,255,0.4)', fontStyle: 'italic', fontSize: '0.75rem' }}>
-          Part of the digital heirloom archive. All entries are preserved for future generations.
-        </Typography>
-      </Box>
     </Drawer>
   );
 };


### PR DESCRIPTION
Raise the INSTRUMENTS panel z-index above the PersonDetailDrawer so the search prev/next arrows stay clickable while a node's detail drawer is open, allowing users to toggle through matches. Also removes the archive footer note from the detail drawer.