### PR TITLE
fix(contrast): improve label legibility in 2D and 3D (LIN-35)

### DIFF
--- a/src/components/FamilyTree3D.tsx
+++ b/src/components/FamilyTree3D.tsx
@@ -1004,6 +1004,10 @@ export const FamilyTree3DContent: React.FC<FamilyTree3DProps> = ({
 
         const sprite = new SpriteText(displayName);
         sprite.color = '#ffffff';
+        // Dark backing plate so labels stay legible over bright spheres / busy scenes
+        sprite.backgroundColor = 'rgba(5, 5, 5, 0.6)';
+        sprite.padding = isMob ? 1.5 : 2;
+        sprite.borderRadius = 2;
         // Smaller text on mobile
         sprite.textHeight = isMob ? 3.5 : 4;
         sprite.fontWeight = 'bold';

--- a/src/utils/familyColors.ts
+++ b/src/utils/familyColors.ts
@@ -45,13 +45,44 @@ function hexToRgb(hex: string): [number, number, number] | null {
   return m ? [parseInt(m[1], 16), parseInt(m[2], 16), parseInt(m[3], 16)] : null;
 }
 
-function isLight(hex: string): boolean {
-  const rgb = hexToRgb(hex);
-  if (!rgb) return false;
-  const [r, g, b] = rgb;
-  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
-  return luminance > 0.6;
+type RGB = [number, number, number];
+
+function relativeLuminance([r, g, b]: RGB): number {
+  const toLinear = (c: number) => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * toLinear(r) + 0.7152 * toLinear(g) + 0.0722 * toLinear(b);
 }
+
+function contrastRatio(a: RGB, b: RGB): number {
+  const la = relativeLuminance(a);
+  const lb = relativeLuminance(b);
+  const [hi, lo] = la >= lb ? [la, lb] : [lb, la];
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+/** Pick black or white text for best WCAG contrast against a solid background. */
+export function getContrastText(bg: RGB): '#000' | '#fff' {
+  return contrastRatio(bg, [255, 255, 255]) >= contrastRatio(bg, [0, 0, 0])
+    ? '#fff'
+    : '#000';
+}
+
+/** Composite a translucent foreground over an opaque base color. */
+function compositeOver(fg: RGB, alpha: number, base: RGB): RGB {
+  return [
+    Math.round(fg[0] * alpha + base[0] * (1 - alpha)),
+    Math.round(fg[1] * alpha + base[1] * (1 - alpha)),
+    Math.round(fg[2] * alpha + base[2] * (1 - alpha)),
+  ];
+}
+
+/** App canvas is near-black; cards are painted as translucent hue over it. */
+const CANVAS_BASE: RGB = [5, 5, 5];
+const CARD_BG_ALPHA = 0.15;
+const FALLBACK_RGB: RGB = [100, 100, 100];
+const FALLBACK_ALPHA = 0.2;
 
 export function getClusterColors(cluster: string | undefined | null): {
   bg: string;
@@ -59,16 +90,23 @@ export function getClusterColors(cluster: string | undefined | null): {
   text: string;
 } {
   if (!cluster) {
-    return { bg: 'rgba(100, 100, 100, 0.2)', border: '#888', text: '#fff' };
+    return {
+      bg: `rgba(100, 100, 100, ${FALLBACK_ALPHA})`,
+      border: '#888',
+      text: getContrastText(compositeOver(FALLBACK_RGB, FALLBACK_ALPHA, CANVAS_BASE)),
+    };
   }
   const hex = getClusterColor(cluster, '#888');
   const rgb = hexToRgb(hex);
   const bg = rgb
-    ? `rgba(${rgb[0]}, ${rgb[1]}, ${rgb[2]}, 0.15)`
-    : 'rgba(100, 100, 100, 0.2)';
+    ? `rgba(${rgb[0]}, ${rgb[1]}, ${rgb[2]}, ${CARD_BG_ALPHA})`
+    : `rgba(100, 100, 100, ${FALLBACK_ALPHA})`;
+  const effectiveBg = rgb
+    ? compositeOver(rgb, CARD_BG_ALPHA, CANVAS_BASE)
+    : compositeOver(FALLBACK_RGB, FALLBACK_ALPHA, CANVAS_BASE);
   return {
     bg,
     border: hex,
-    text: isLight(hex) ? '#000' : '#fff',
+    text: getContrastText(effectiveBg),
   };
 }


### PR DESCRIPTION
## Summary
Improves text/background contrast so node labels stay readable in both views (LIN-35).

- **2D:** Node-card text color is now chosen against the *actual* composited background (translucent family hue over the near-black canvas) using a WCAG relative-luminance helper, instead of the raw saturated hue. Light-colored families (Kutob, Tamimi, Masri, Qudsi, Dajani, etc.) now get readable white text instead of unreadable black-on-dark. The maternal-only lightened path inherits the corrected color automatically.
- **3D:** Each node label (`SpriteText`) gets a subtle dark backing plate (`backgroundColor` + `padding` + `borderRadius`) so white names stay legible over bright spheres, nebulae, and the starfield.

## Scope
- `src/utils/familyColors.ts` — add `getContrastText` / luminance + composite helpers; fix `getClusterColors` text.
- `src/components/FamilyTree3D.tsx` — dark backing plate on label sprites.

(Project-rename file changes are intentionally excluded from this PR.)

## Verification
Verified live: 2D Kutob family renders readable white text on dark cards; 3D labels show the dark backing plate and stay legible. `tsc --noEmit` and lint pass.