### PR TITLE
feat(3d): family cluster bubbles on zoom-out (LIN-32)

### DIFF
--- a/src/components/FamilyTree3D.tsx
+++ b/src/components/FamilyTree3D.tsx
@@ -20,6 +20,7 @@ import { getTexturePath } from '../utils/imageFormat';
 import { getClusterColors } from '../utils/familyColors';
 import { getNodeId } from '../utils/getNodeId';
 import { filterGraphDataFor3D } from '../lib/filterGraphData';
+import { useClusterBubbles } from '../hooks/useClusterBubbles';
 import { TreeSearchBar } from './TreeSearchBar';
 
 // V3 Shared Assets - paths resolved at runtime for WebP when supported
@@ -378,13 +379,26 @@ export const FamilyTree3DContent: React.FC<FamilyTree3DProps> = ({
     }
   }, [graphData, effectiveCollapsedNodes, visibleClusters3D, uniqueClusters, pendingLinkPreview]);
 
+  // Family cluster view on zoom-out (LIN-32): fades individuals into per-cluster
+  // bubbles when zoomed out. `detailRef` (0..1) drives the node fade below;
+  // `fullyClustered` hides individuals/links entirely once fully zoomed out.
+  const { detailRef, fullyClustered } = useClusterBubbles({
+    fgRef,
+    graphData: filteredGraphData,
+    visibleClusters: visibleClusters3D,
+    enabled: (filteredGraphData.nodes?.length ?? 0) > 0,
+  });
+
   // three-forcegraph multiplies linkOpacity as a number (arrows use state.linkOpacity * 3).
   // Per-link visibility must use linkVisibility, not a function passed to linkOpacity.
   const linkVisibility = useCallback((l: any) => {
     if (isPreviewLink(l)) return true;
+    if (fullyClustered) return false;
     if (l.type === 'parent') return showLinks || showArrows;
     return showLinks;
-  }, [showLinks, showArrows]);
+  }, [showLinks, showArrows, fullyClustered]);
+
+  const nodeVisibility = useCallback(() => !fullyClustered, [fullyClustered]);
 
   const linkMaterial = useCallback((l: any) => {
     if (isPreviewLink(l)) {
@@ -968,6 +982,9 @@ export const FamilyTree3DContent: React.FC<FamilyTree3DProps> = ({
 
       if (nodeTexture !== 'none') {
         const material = nodeTexture === 'planets' ? getPlanetMaterial(node.id, isMob) : getMaterial(color, isMob);
+        if (material.userData.baseOpacity === undefined) {
+          material.userData.baseOpacity = material.opacity;
+        }
         const sphere = new THREE.Mesh(geometries.sphere, material);
         group.add(sphere);
 
@@ -977,6 +994,9 @@ export const FamilyTree3DContent: React.FC<FamilyTree3DProps> = ({
           const rot = rotationRef.current * speedFactor;
           sphere.rotation.y = rot;
           sphere.rotation.z = rot * 0.5;
+          // Crossfade individuals out as cluster bubbles fade in (LIN-32).
+          material.transparent = true;
+          material.opacity = material.userData.baseOpacity * (1 - detailRef.current);
         };
 
         if (isSelected) {
@@ -1014,6 +1034,11 @@ export const FamilyTree3DContent: React.FC<FamilyTree3DProps> = ({
         sprite.position.set(0, 0, 0);
         sprite.renderOrder = 999;
         sprite.material.depthTest = false;
+        sprite.material.transparent = true;
+        // Fade the label together with its sphere when zooming out (LIN-32).
+        sprite.onBeforeRender = () => {
+          sprite.material.opacity = 1 - detailRef.current;
+        };
         group.add(sprite);
       }
 
@@ -1022,7 +1047,7 @@ export const FamilyTree3DContent: React.FC<FamilyTree3DProps> = ({
       console.error('[FamilyTree3D] Error in nodeThreeObject:', err);
       return new THREE.Group();
     }
-  }, [selectedNode, showNames, nodeTexture, geometries, rotationRef, searchHighlightedNodeId]);
+  }, [selectedNode, showNames, nodeTexture, geometries, rotationRef, searchHighlightedNodeId, detailRef]);
 
   useEffect(() => {
     if (fgRef.current?.refresh) fgRef.current.refresh();
@@ -1293,6 +1318,7 @@ export const FamilyTree3DContent: React.FC<FamilyTree3DProps> = ({
         linkStrength={(l: any) =>
           isPreviewLink(l) ? 0 : activePreset ? 0.1 : (l.type === 'marriage' || l.type === 'divorce' ? 0.3 : 0.8)}
         ref={fgRef}
+        nodeVisibility={nodeVisibility}
         warmupTicks={160}
         d3AlphaDecay={0.01}
         d3VelocityDecay={0.1}

--- a/src/hooks/useClusterBubbles.ts
+++ b/src/hooks/useClusterBubbles.ts
@@ -1,0 +1,414 @@
+import { useEffect, useRef, useState } from 'react';
+import * as THREE from 'three';
+import SpriteText from 'three-spritetext';
+import { getClusterColors } from '../utils/familyColors';
+import { isMobile } from '../utils/device';
+import {
+  computeVisibleBounds,
+  computeClusterCentroids,
+  bubbleRadius,
+  detailFactor,
+  apparentDiameterFraction,
+  ramp01,
+  EXIT_MULT,
+  BUBBLE_FADE_MIN,
+  BUBBLE_FADE_FULL,
+  LABEL_FADE_MIN,
+  LABEL_FADE_FULL,
+  GLASS_BASE_OPACITY,
+  HOVER_SCALE,
+  HOVER_EMISSIVE_INTENSITY,
+  HOVER_LERP,
+  type LiveNode,
+  type Vec3,
+} from '../utils/clusterBubbles';
+
+/**
+ * 3D "family cluster on zoom-out" (LIN-32).
+ *
+ * Watches the camera distance each frame and, when zoomed out, fades in one big
+ * sphere per paternal familyCluster positioned at the live centroid of its
+ * members and sized by member count. Clicking a bubble flies the camera in so
+ * the cluster expands back into individuals.
+ *
+ * The bubbles are our own THREE objects added to the force-graph's scene
+ * because react-force-graph-3d renders one object per data node and offers no
+ * overlay hook. Returns:
+ *  - `detailRef`: live crossfade factor (0 = individuals, 1 = clusters). Read by
+ *    the component inside `onBeforeRender` to fade individual nodes.
+ *  - `fullyClustered`: hysteresis-gated boolean; when true the component hides
+ *    individual nodes/links entirely (performance).
+ */
+/** Minimal slice of the react-force-graph-3d instance this hook calls. */
+interface ForceGraphHandle {
+  scene?: () => THREE.Scene;
+  camera?: () => THREE.PerspectiveCamera;
+  controls?: () => { target?: THREE.Vector3 } | undefined;
+  renderer?: () => THREE.WebGLRenderer | undefined;
+  cameraPosition: (
+    pos: { x: number; y: number; z: number },
+    lookAt?: { x: number; y: number; z: number },
+    transitionMs?: number
+  ) => void;
+}
+
+export function useClusterBubbles(params: {
+  fgRef: React.MutableRefObject<ForceGraphHandle | null | undefined>;
+  graphData: { nodes: LiveNode[]; links: unknown[] };
+  visibleClusters: Set<string>;
+  enabled: boolean;
+}): { detailRef: React.MutableRefObject<number>; fullyClustered: boolean } {
+  const { fgRef, graphData, visibleClusters, enabled } = params;
+
+  const detailRef = useRef(0);
+  const [fullyClustered, setFullyClustered] = useState(false);
+  const fullyClusteredRef = useRef(false);
+
+  // Latest inputs read by the rAF loop without restarting it.
+  const graphDataRef = useRef(graphData);
+  graphDataRef.current = graphData;
+  const visibleClustersRef = useRef(visibleClusters);
+  visibleClustersRef.current = visibleClusters;
+  const enabledRef = useRef(enabled);
+  enabledRef.current = enabled;
+
+  // Latest graph bounds, shared with the click handler for fly-in distance.
+  const boundsRef = useRef<{ centroid: Vec3; radius: number }>({
+    centroid: { x: 0, y: 0, z: 0 },
+    radius: 0,
+  });
+
+  useEffect(() => {
+    const SHARED_GEOMETRY = new THREE.SphereGeometry(1, 24, 24);
+    const isMob = isMobile();
+
+    interface Bubble {
+      group: THREE.Group;
+      mesh: THREE.Mesh;
+      material: THREE.MeshStandardMaterial | THREE.MeshPhysicalMaterial;
+      sprite: SpriteText;
+      labelText: string;
+      /** Hover state: target (0/1) set by pointermove, amt eased toward it each frame. */
+      hoverTarget: number;
+      hoverAmt: number;
+    }
+
+    let sceneGroup: THREE.Group | null = null;
+    const bubbles = new Map<string, Bubble>();
+
+    const createBubble = (cluster: string): Bubble => {
+      const color = getClusterColors(cluster).border;
+      // Frosted-glass planet, mirroring the individual-node material (getMaterial)
+      // so bubbles read as the same family of object. Emissive ramps in on hover.
+      const params = {
+        color,
+        transparent: true,
+        opacity: 0,
+        roughness: 0.8,
+        metalness: 0.2,
+        side: THREE.DoubleSide,
+        emissive: new THREE.Color(color),
+        emissiveIntensity: 0,
+      };
+      const material = isMob
+        ? new THREE.MeshStandardMaterial(params)
+        : new THREE.MeshPhysicalMaterial({
+            ...params,
+            clearcoat: 1.0,
+            clearcoatRoughness: 0.1,
+            transmission: 0.3,
+            thickness: 2,
+          });
+      const mesh = new THREE.Mesh(SHARED_GEOMETRY, material);
+
+      const sprite = new SpriteText('');
+      sprite.color = '#ffffff';
+      sprite.backgroundColor = 'rgba(5, 5, 5, 0.6)';
+      sprite.padding = 3;
+      sprite.borderRadius = 3;
+      sprite.fontWeight = 'bold';
+      sprite.material.depthTest = false;
+      sprite.material.transparent = true;
+      sprite.renderOrder = 999;
+
+      const group = new THREE.Group();
+      group.add(mesh);
+      group.add(sprite);
+
+      return { group, mesh, material, sprite, labelText: '', hoverTarget: 0, hoverAmt: 0 };
+    };
+
+    const disposeBubble = (b: Bubble) => {
+      sceneGroup?.remove(b.group);
+      b.material.dispose();
+      // SpriteText owns a canvas-backed texture/material it created internally.
+      const spriteMat = b.sprite.material as THREE.SpriteMaterial;
+      spriteMat.map?.dispose();
+      spriteMat.dispose();
+    };
+
+    // `dist`/`fovRad` describe the current camera so each bubble can be faded by
+    // its on-screen size (declutter). They are unused when t collapses to 0.
+    const updateBubbles = (t: number, dist: number, fovRad: number) => {
+      if (!sceneGroup) return;
+      sceneGroup.visible = t > 0.001;
+
+      const centroids = computeClusterCentroids(graphDataRef.current.nodes);
+      const visible = visibleClustersRef.current;
+
+      // Largest cluster across the whole graph (not just visible ones, so toggling
+      // visibility doesn't rescale the rest) — the "sun" that bubbleRadius normalizes to.
+      let maxCount = 1;
+      for (const agg of centroids.values()) {
+        if (agg.count > maxCount) maxCount = agg.count;
+      }
+
+      // Remove bubbles whose cluster is gone or no longer visible.
+      for (const [cluster, bubble] of bubbles) {
+        if (!centroids.has(cluster) || !visible.has(cluster)) {
+          disposeBubble(bubble);
+          bubbles.delete(cluster);
+        }
+      }
+
+      if (t <= 0.001) return;
+
+      for (const [cluster, agg] of centroids) {
+        if (!visible.has(cluster)) continue;
+
+        let bubble = bubbles.get(cluster);
+        if (!bubble) {
+          bubble = createBubble(cluster);
+          bubbles.set(cluster, bubble);
+          sceneGroup.add(bubble.group);
+        }
+
+        bubble.group.position.set(agg.centroid.x, agg.centroid.y, agg.centroid.z);
+        const radius = bubbleRadius(agg.count, maxCount);
+
+        // Hover (LIN-32 #4): ease toward the target each frame, then grow & brighten.
+        bubble.hoverAmt += (bubble.hoverTarget - bubble.hoverAmt) * HOVER_LERP;
+        bubble.mesh.scale.setScalar(radius * (1 + HOVER_SCALE * bubble.hoverAmt));
+        bubble.material.emissiveIntensity = HOVER_EMISSIVE_INTENSITY * bubble.hoverAmt;
+
+        // Declutter: fade the bubble (and, on a stricter band, its label) by how
+        // big it actually renders on screen, so small/distant planets drop away
+        // when zoomed out and only prominent families stay labelled (LIN-32 #3).
+        const apparent = apparentDiameterFraction(radius, dist, fovRad);
+        const bubbleVis = ramp01(apparent, BUBBLE_FADE_MIN, BUBBLE_FADE_FULL);
+        const labelVis = ramp01(apparent, LABEL_FADE_MIN, LABEL_FADE_FULL);
+        bubble.material.opacity = GLASS_BASE_OPACITY * t * bubbleVis;
+
+        const label = `${cluster}\n(${agg.count})`;
+        if (label !== bubble.labelText) {
+          bubble.sprite.text = label;
+          bubble.labelText = label;
+        }
+        bubble.sprite.textHeight = Math.max(16, radius * 0.32);
+        (bubble.sprite.material as THREE.SpriteMaterial).opacity = t * labelVis;
+      }
+    };
+
+    // --- Click-to-expand (raycast against bubble meshes) ---
+    const raycaster = new THREE.Raycaster();
+    const pointer = new THREE.Vector2();
+    const downAt = { x: 0, y: 0, time: 0 };
+
+    const flyIntoCluster = (centroid: Vec3) => {
+      const fg = fgRef.current;
+      if (!fg) return;
+      const camera = fg.camera?.();
+      if (!camera) return;
+
+      const centroidVec = new THREE.Vector3(centroid.x, centroid.y, centroid.z);
+      const dir = camera.position.clone().sub(centroidVec);
+      if (!Number.isFinite(dir.lengthSq()) || dir.lengthSq() < 1e-6) {
+        dir.set(0, 0, 1);
+      } else {
+        dir.normalize();
+      }
+      // Approach close enough that detailFactor drops to 0 (individuals expand).
+      const radius = boundsRef.current.radius || 200;
+      const dist = Math.max(90, EXIT_MULT * radius * 0.7);
+      const newPos = centroidVec.clone().add(dir.multiplyScalar(dist));
+      fg.cameraPosition(
+        { x: newPos.x, y: newPos.y, z: newPos.z },
+        { x: centroid.x, y: centroid.y, z: centroid.z },
+        1200
+      );
+    };
+
+    const getDomElement = (): HTMLElement | null => {
+      const fg = fgRef.current;
+      try {
+        return fg?.renderer?.()?.domElement ?? null;
+      } catch {
+        return null;
+      }
+    };
+
+    const onPointerDown = (e: PointerEvent) => {
+      downAt.x = e.clientX;
+      downAt.y = e.clientY;
+      downAt.time = Date.now();
+    };
+
+    const onPointerUp = (e: PointerEvent) => {
+      // Ignore drags (camera rotate/pan) and only act while bubbles are showing.
+      const moved = Math.hypot(e.clientX - downAt.x, e.clientY - downAt.y);
+      if (moved > 6 || Date.now() - downAt.time > 400) return;
+      if (detailRef.current < 0.5 || bubbles.size === 0) return;
+
+      const fg = fgRef.current;
+      const dom = getDomElement();
+      const camera = fg?.camera?.();
+      if (!fg || !dom || !camera) return;
+
+      const rect = dom.getBoundingClientRect();
+      pointer.x = ((e.clientX - rect.left) / rect.width) * 2 - 1;
+      pointer.y = -((e.clientY - rect.top) / rect.height) * 2 + 1;
+      raycaster.setFromCamera(pointer, camera);
+
+      // Only faded-in bubbles are clickable (skip ones decluttered to ~invisible).
+      const meshes = Array.from(bubbles.values())
+        .filter((b) => b.material.opacity > 0.05)
+        .map((b) => b.mesh);
+      const hits = raycaster.intersectObjects(meshes, false);
+      if (hits.length === 0) return;
+
+      const hitMesh = hits[0].object;
+      let hitCluster: string | null = null;
+      for (const [cluster, b] of bubbles) {
+        if (b.mesh === hitMesh) {
+          hitCluster = cluster;
+          break;
+        }
+      }
+      if (!hitCluster) return;
+
+      const agg = computeClusterCentroids(graphDataRef.current.nodes).get(hitCluster);
+      if (agg) flyIntoCluster(agg.centroid);
+    };
+
+    // --- Hover (LIN-32 #4): highlight the bubble under the cursor + show a pointer ---
+    let listenerDom: HTMLElement | null = null;
+    let hoverCursorActive = false;
+    const onPointerMove = (e: PointerEvent) => {
+      const dom = getDomElement();
+      const camera = fgRef.current?.camera?.();
+      if (!dom || !camera) return;
+
+      let hovered: string | null = null;
+      if (detailRef.current >= 0.5 && bubbles.size > 0) {
+        const rect = dom.getBoundingClientRect();
+        pointer.x = ((e.clientX - rect.left) / rect.width) * 2 - 1;
+        pointer.y = -((e.clientY - rect.top) / rect.height) * 2 + 1;
+        raycaster.setFromCamera(pointer, camera);
+        const entries = Array.from(bubbles.entries()).filter(([, b]) => b.material.opacity > 0.05);
+        const hits = raycaster.intersectObjects(entries.map(([, b]) => b.mesh), false);
+        if (hits.length > 0) {
+          const found = entries.find(([, b]) => b.mesh === hits[0].object);
+          hovered = found ? found[0] : null;
+        }
+      }
+
+      // The actual cursor is asserted each frame in the tick (it has to run after
+      // react-force-graph's own loop, which otherwise resets the cursor).
+      for (const [cluster, b] of bubbles) b.hoverTarget = cluster === hovered ? 1 : 0;
+    };
+
+    const clearHover = () => {
+      for (const b of bubbles.values()) b.hoverTarget = 0;
+      if (hoverCursorActive && listenerDom) listenerDom.style.cursor = '';
+      hoverCursorActive = false;
+    };
+
+    const attachListeners = (dom: HTMLElement | null) => {
+      if (!dom || listenerDom === dom) return;
+      detachListeners();
+      dom.addEventListener('pointerdown', onPointerDown);
+      dom.addEventListener('pointerup', onPointerUp);
+      dom.addEventListener('pointermove', onPointerMove);
+      listenerDom = dom;
+    };
+    const detachListeners = () => {
+      if (!listenerDom) return;
+      clearHover();
+      listenerDom.removeEventListener('pointerdown', onPointerDown);
+      listenerDom.removeEventListener('pointerup', onPointerUp);
+      listenerDom.removeEventListener('pointermove', onPointerMove);
+      listenerDom = null;
+    };
+
+    // --- Per-frame loop ---
+    let frameId = 0;
+    const tick = () => {
+      frameId = requestAnimationFrame(tick);
+      const fg = fgRef.current;
+      if (!fg || !enabledRef.current) {
+        if (detailRef.current !== 0) {
+          detailRef.current = 0;
+          updateBubbles(0, 0, 0);
+        }
+        return;
+      }
+
+      const scene = fg.scene?.();
+      const camera = fg.camera?.();
+      const controls = fg.controls?.();
+      if (!scene || !camera || !controls?.target) return;
+
+      if (!sceneGroup) {
+        sceneGroup = new THREE.Group();
+        sceneGroup.name = 'cluster-bubbles';
+        scene.add(sceneGroup);
+      }
+      attachListeners(getDomElement());
+
+      const bounds = computeVisibleBounds(graphDataRef.current.nodes);
+      boundsRef.current = bounds;
+
+      const dist = camera.position.distanceTo(controls.target);
+      const fovRad = ((camera.fov || 60) * Math.PI) / 180;
+      const t = detailFactor(dist, bounds.radius);
+      detailRef.current = t;
+
+      // Hysteresis so individual nodes don't flicker at the threshold.
+      if (!fullyClusteredRef.current && t >= 0.999) {
+        fullyClusteredRef.current = true;
+        setFullyClustered(true);
+      } else if (fullyClusteredRef.current && t < 0.9) {
+        fullyClusteredRef.current = false;
+        setFullyClustered(false);
+      }
+
+      updateBubbles(t, dist, fovRad);
+
+      // Show a pointer cursor while a bubble is hovered. Done here (not in the
+      // pointer handler) because this loop runs after react-force-graph's own,
+      // which resets the cursor every frame; reassert it so ours wins.
+      let anyHovered = false;
+      for (const b of bubbles.values()) if (b.hoverTarget > 0) { anyHovered = true; break; }
+      if (anyHovered) {
+        if (listenerDom) listenerDom.style.cursor = 'pointer';
+        hoverCursorActive = true;
+      } else if (hoverCursorActive) {
+        if (listenerDom) listenerDom.style.cursor = '';
+        hoverCursorActive = false;
+      }
+    };
+    frameId = requestAnimationFrame(tick);
+
+    return () => {
+      cancelAnimationFrame(frameId);
+      detachListeners();
+      for (const bubble of bubbles.values()) disposeBubble(bubble);
+      bubbles.clear();
+      if (sceneGroup && sceneGroup.parent) sceneGroup.parent.remove(sceneGroup);
+      sceneGroup = null;
+      SHARED_GEOMETRY.dispose();
+    };
+  }, [fgRef]);
+
+  return { detailRef, fullyClustered };
+}

--- a/src/utils/clusterBubbles.test.ts
+++ b/src/utils/clusterBubbles.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeVisibleBounds,
+  computeClusterCentroids,
+  bubbleRadius,
+  detailFactor,
+  apparentDiameterFraction,
+  ramp01,
+  type LiveNode,
+  ENTER_MULT,
+  EXIT_MULT,
+  MIN_BUBBLE_RADIUS,
+  MAX_BUBBLE_RADIUS,
+} from './clusterBubbles';
+
+describe('computeVisibleBounds', () => {
+  it('returns origin/zero for no positioned nodes', () => {
+    expect(computeVisibleBounds([])).toEqual({ centroid: { x: 0, y: 0, z: 0 }, radius: 0 });
+    expect(computeVisibleBounds([{ familyCluster: 'A' }])).toEqual({
+      centroid: { x: 0, y: 0, z: 0 },
+      radius: 0,
+    });
+  });
+
+  it('computes centroid and bounding radius from positions', () => {
+    const nodes: LiveNode[] = [
+      { x: -10, y: 0, z: 0 },
+      { x: 10, y: 0, z: 0 },
+    ];
+    const { centroid, radius } = computeVisibleBounds(nodes);
+    expect(centroid).toEqual({ x: 0, y: 0, z: 0 });
+    expect(radius).toBeCloseTo(10);
+  });
+
+  it('ignores nodes with non-finite positions', () => {
+    const nodes: LiveNode[] = [
+      { x: 0, y: 0, z: 0 },
+      { x: NaN, y: 5, z: 5 },
+      { x: 6, y: 0, z: 0 },
+    ];
+    const { centroid } = computeVisibleBounds(nodes);
+    expect(centroid).toEqual({ x: 3, y: 0, z: 0 });
+  });
+});
+
+describe('computeClusterCentroids', () => {
+  it('groups by familyCluster and counts members', () => {
+    const nodes: LiveNode[] = [
+      { x: 0, y: 0, z: 0, familyCluster: 'Badran' },
+      { x: 10, y: 0, z: 0, familyCluster: 'Badran' },
+      { x: 100, y: 100, z: 100, familyCluster: 'Kutob' },
+    ];
+    const result = computeClusterCentroids(nodes);
+    expect(result.size).toBe(2);
+    expect(result.get('Badran')).toEqual({ centroid: { x: 5, y: 0, z: 0 }, count: 2 });
+    expect(result.get('Kutob')).toEqual({
+      centroid: { x: 100, y: 100, z: 100 },
+      count: 1,
+    });
+  });
+
+  it('skips nodes without a cluster and trims names', () => {
+    const nodes: LiveNode[] = [
+      { x: 0, y: 0, z: 0 },
+      { x: 1, y: 1, z: 1, familyCluster: '   ' },
+      { x: 4, y: 0, z: 0, familyCluster: ' Badran ' },
+    ];
+    const result = computeClusterCentroids(nodes);
+    expect(result.size).toBe(1);
+    expect(result.get('Badran')?.count).toBe(1);
+  });
+
+  it('counts a member even if unpositioned, but centroids only over positioned ones', () => {
+    const nodes: LiveNode[] = [
+      { x: 0, y: 0, z: 0, familyCluster: 'Badran' },
+      { x: 10, y: 0, z: 0, familyCluster: 'Badran' },
+      { familyCluster: 'Badran' },
+    ];
+    const result = computeClusterCentroids(nodes);
+    expect(result.get('Badran')).toEqual({ centroid: { x: 5, y: 0, z: 0 }, count: 3 });
+  });
+
+  it('omits clusters with no positioned members', () => {
+    const nodes: LiveNode[] = [{ familyCluster: 'Ghosts' }];
+    expect(computeClusterCentroids(nodes).size).toBe(0);
+  });
+});
+
+describe('bubbleRadius', () => {
+  it('sizes the largest cluster as the full "sun"', () => {
+    expect(bubbleRadius(405, 405)).toBe(MAX_BUBBLE_RADIUS);
+    expect(bubbleRadius(7, 7)).toBe(MAX_BUBBLE_RADIUS);
+  });
+
+  it('floors tiny / empty clusters at the minimum', () => {
+    expect(bubbleRadius(1, 405)).toBe(MIN_BUBBLE_RADIUS);
+    expect(bubbleRadius(0, 405)).toBe(MIN_BUBBLE_RADIUS);
+  });
+
+  it('grows monotonically with member count for a fixed max', () => {
+    expect(bubbleRadius(200, 405)).toBeGreaterThan(bubbleRadius(20, 405));
+    expect(bubbleRadius(20, 405)).toBeGreaterThanOrEqual(bubbleRadius(5, 405));
+  });
+
+  it('gives the dominant family a strong size lead ("sun vs planets")', () => {
+    // A 405-member family should dwarf a singleton, unlike the old ~2.4x.
+    expect(bubbleRadius(405, 405)).toBeGreaterThanOrEqual(bubbleRadius(1, 405) * 5);
+  });
+
+  it('is area-proportional: 4x the members ≈ 2x the radius', () => {
+    // radius ∝ √count, so quadrupling members doubles the radius (above the floor).
+    expect(bubbleRadius(400, 400)).toBeCloseTo(bubbleRadius(100, 400) * 2);
+  });
+});
+
+describe('detailFactor', () => {
+  const R = 100;
+
+  it('is 0 when zoomed in (below exit distance)', () => {
+    expect(detailFactor(EXIT_MULT * R - 1, R)).toBe(0);
+    expect(detailFactor(0, R)).toBe(0);
+  });
+
+  it('is 1 when zoomed out (beyond enter distance)', () => {
+    expect(detailFactor(ENTER_MULT * R + 1, R)).toBe(1);
+  });
+
+  it('ramps smoothly between exit and enter', () => {
+    const mid = ((EXIT_MULT + ENTER_MULT) / 2) * R;
+    const t = detailFactor(mid, R);
+    expect(t).toBeGreaterThan(0);
+    expect(t).toBeLessThan(1);
+    expect(t).toBeCloseTo(0.5);
+  });
+
+  it('returns 0 for a degenerate (zero-radius) graph', () => {
+    expect(detailFactor(5000, 0)).toBe(0);
+  });
+});
+
+describe('apparentDiameterFraction', () => {
+  // 90° vertical FOV => tan(fov/2) = 1, so fraction = radius / distance.
+  const FOV_90 = Math.PI / 2;
+
+  it('shrinks as the camera moves away (∝ 1/distance)', () => {
+    const near = apparentDiameterFraction(100, 1000, FOV_90);
+    const far = apparentDiameterFraction(100, 2000, FOV_90);
+    expect(near).toBeCloseTo(0.1);
+    expect(far).toBeCloseTo(0.05);
+  });
+
+  it('grows with bubble radius (a "sun" stays visible far longer than a "planet")', () => {
+    expect(apparentDiameterFraction(600, 8000, FOV_90)).toBeGreaterThan(
+      apparentDiameterFraction(50, 8000, FOV_90)
+    );
+  });
+
+  it('returns Infinity at zero distance / bad inputs (always visible)', () => {
+    expect(apparentDiameterFraction(100, 0, FOV_90)).toBe(Infinity);
+    expect(apparentDiameterFraction(100, 1000, 0)).toBe(Infinity);
+  });
+});
+
+describe('ramp01', () => {
+  it('clamps below lo and above hi', () => {
+    expect(ramp01(-5, 0, 10)).toBe(0);
+    expect(ramp01(0, 0, 10)).toBe(0);
+    expect(ramp01(10, 0, 10)).toBe(1);
+    expect(ramp01(99, 0, 10)).toBe(1);
+  });
+
+  it('ramps linearly between lo and hi', () => {
+    expect(ramp01(5, 0, 10)).toBeCloseTo(0.5);
+    expect(ramp01(2.5, 0, 10)).toBeCloseTo(0.25);
+  });
+
+  it('treats a degenerate band as a hard step', () => {
+    expect(ramp01(4, 5, 5)).toBe(0);
+    expect(ramp01(5, 5, 5)).toBe(1);
+  });
+});

--- a/src/utils/clusterBubbles.ts
+++ b/src/utils/clusterBubbles.ts
@@ -1,0 +1,188 @@
+/**
+ * Pure helpers for the 3D "family cluster on zoom-out" feature (LIN-32).
+ *
+ * These functions are framework-agnostic (no THREE / React) so they can be
+ * unit-tested in isolation. The hook `useClusterBubbles` applies their output
+ * to the live Three.js scene each frame.
+ */
+
+export interface Vec3 {
+  x: number;
+  y: number;
+  z: number;
+}
+
+/** Minimal shape of a live force-graph node (positions are attached at runtime). */
+export interface LiveNode {
+  x?: number;
+  y?: number;
+  z?: number;
+  familyCluster?: string;
+}
+
+// --- Tuning constants (exported for live tweaking) ---
+
+/** Begin fully clustering once camera distance exceeds ENTER_MULT * graphRadius. */
+export const ENTER_MULT = 1.5;
+/** Return to full detail once camera distance drops below EXIT_MULT * graphRadius. */
+export const EXIT_MULT = 1.0;
+
+/** Smallest "planet" bubble — small but still visible and clickable. (tunable) */
+export const MIN_BUBBLE_RADIUS = 50;
+/** The dominant "sun" — radius of the single largest cluster. (tunable) */
+export const MAX_BUBBLE_RADIUS = 600;
+/** Exponent on a cluster's share of the largest cluster. 0.5 = area-proportional. */
+export const BUBBLE_SIZE_EXPONENT = 0.5;
+
+// --- Declutter (LIN-32 #3): fade bubbles & labels by their on-screen size, so
+// small/distant families drop away when zoomed out instead of colliding. All are
+// fractions of viewport height; labels use a higher band than bubbles so only
+// prominent families stay labelled. (tunable)
+/** Bubble opacity ramps 0→1 as its on-screen diameter crosses this band. */
+export const BUBBLE_FADE_MIN = 0.012;
+export const BUBBLE_FADE_FULL = 0.03;
+/** A bubble shows its label only as its on-screen diameter crosses this (higher) band. */
+export const LABEL_FADE_MIN = 0.05;
+export const LABEL_FADE_FULL = 0.1;
+
+// --- Look & feel (LIN-32 #4): frosted-glass bubbles + hover affordance. (tunable) ---
+/** Peak opacity of a fully-faded-in bubble (matches the glassy individual-node look). */
+export const GLASS_BASE_OPACITY = 0.5;
+/** Extra scale a bubble grows by while hovered (0.06 = +6%). */
+export const HOVER_SCALE = 0.06;
+/** Emissive intensity a bubble brightens to while hovered. */
+export const HOVER_EMISSIVE_INTENSITY = 0.5;
+/** Per-frame lerp factor easing the hover in/out (0..1; higher = snappier). */
+export const HOVER_LERP = 0.15;
+
+function isFinitePos(node: LiveNode): node is LiveNode & Vec3 {
+  return (
+    typeof node.x === 'number' && Number.isFinite(node.x) &&
+    typeof node.y === 'number' && Number.isFinite(node.y) &&
+    typeof node.z === 'number' && Number.isFinite(node.z)
+  );
+}
+
+/**
+ * Centroid and bounding radius (max distance from centroid) of all positioned
+ * nodes. Used to scale the zoom thresholds to the actual graph size.
+ */
+export function computeVisibleBounds(nodes: ReadonlyArray<LiveNode>): {
+  centroid: Vec3;
+  radius: number;
+} {
+  let sx = 0, sy = 0, sz = 0, n = 0;
+  for (const node of nodes) {
+    if (!isFinitePos(node)) continue;
+    sx += node.x; sy += node.y; sz += node.z; n++;
+  }
+  if (n === 0) return { centroid: { x: 0, y: 0, z: 0 }, radius: 0 };
+
+  const centroid: Vec3 = { x: sx / n, y: sy / n, z: sz / n };
+  let maxDistSq = 0;
+  for (const node of nodes) {
+    if (!isFinitePos(node)) continue;
+    const dx = node.x - centroid.x;
+    const dy = node.y - centroid.y;
+    const dz = node.z - centroid.z;
+    const distSq = dx * dx + dy * dy + dz * dz;
+    if (distSq > maxDistSq) maxDistSq = distSq;
+  }
+  return { centroid, radius: Math.sqrt(maxDistSq) };
+}
+
+export interface ClusterAggregate {
+  centroid: Vec3;
+  /** Total members of this cluster (including any without finite positions). */
+  count: number;
+}
+
+/**
+ * Group nodes by paternal `familyCluster` and return each cluster's member
+ * count plus the centroid of its positioned members. Clusters with no
+ * positioned members are omitted (they cannot be placed).
+ */
+export function computeClusterCentroids(
+  nodes: ReadonlyArray<LiveNode>
+): Map<string, ClusterAggregate> {
+  const acc = new Map<
+    string,
+    { sx: number; sy: number; sz: number; posCount: number; count: number }
+  >();
+
+  for (const node of nodes) {
+    const cluster = node.familyCluster?.trim();
+    if (!cluster) continue;
+    let a = acc.get(cluster);
+    if (!a) {
+      a = { sx: 0, sy: 0, sz: 0, posCount: 0, count: 0 };
+      acc.set(cluster, a);
+    }
+    a.count++;
+    if (isFinitePos(node)) {
+      a.sx += node.x; a.sy += node.y; a.sz += node.z; a.posCount++;
+    }
+  }
+
+  const out = new Map<string, ClusterAggregate>();
+  for (const [cluster, a] of acc) {
+    if (a.posCount === 0) continue;
+    out.set(cluster, {
+      centroid: { x: a.sx / a.posCount, y: a.sy / a.posCount, z: a.sz / a.posCount },
+      count: a.count,
+    });
+  }
+  return out;
+}
+
+/**
+ * World-space radius for a cluster bubble, normalized against the largest
+ * cluster (`maxCount`). The size encodes member count by *area*
+ * (radius ∝ √count, via BUBBLE_SIZE_EXPONENT) so a dominant family reads like a
+ * "sun" at MAX_BUBBLE_RADIUS while the rest shrink to "planets" by the root of
+ * their share. Floored at MIN_BUBBLE_RADIUS so small families stay findable.
+ */
+export function bubbleRadius(count: number, maxCount: number): number {
+  const share = Math.max(1, count) / Math.max(1, maxCount); // 0..1
+  const frac = Math.pow(share, BUBBLE_SIZE_EXPONENT);
+  return Math.max(MIN_BUBBLE_RADIUS, MAX_BUBBLE_RADIUS * frac);
+}
+
+/**
+ * On-screen diameter of a sphere of world `radius` at `distance` from a
+ * perspective camera with vertical field-of-view `fovRadians`, expressed as a
+ * fraction of the viewport height. Returns Infinity when the camera is on top of
+ * it (distance → 0). Drives the declutter fades: a planet that projects to only
+ * a few pixels is faded out so it stops cluttering the zoomed-out overview.
+ */
+export function apparentDiameterFraction(
+  radius: number,
+  distance: number,
+  fovRadians: number
+): number {
+  if (!(distance > 0) || !(fovRadians > 0)) return Infinity;
+  return radius / (distance * Math.tan(fovRadians / 2));
+}
+
+/** Clamped linear ramp: 0 at/below `lo`, 1 at/above `hi`, linear between. */
+export function ramp01(value: number, lo: number, hi: number): number {
+  if (hi <= lo) return value >= hi ? 1 : 0;
+  return Math.min(1, Math.max(0, (value - lo) / (hi - lo)));
+}
+
+/**
+ * Maps camera distance to a crossfade factor in [0, 1]:
+ *   0 = fully zoomed in (show individuals),
+ *   1 = fully zoomed out (show cluster bubbles).
+ * The ramp between EXIT and ENTER distances gives a seamless crossfade rather
+ * than a hard switch. Thresholds scale with the graph's bounding `radius`.
+ */
+export function detailFactor(distance: number, radius: number): number {
+  if (radius <= 0) return 0;
+  const exit = EXIT_MULT * radius;
+  const enter = ENTER_MULT * radius;
+  if (enter <= exit) return 0;
+  if (distance <= exit) return 0;
+  if (distance >= enter) return 1;
+  return (distance - exit) / (enter - exit);
+}


### PR DESCRIPTION
Collapse the 3D family tree into one bubble per paternal family when the camera zooms out, and expand back to individuals on zoom-in or click.

- Sizing: area-proportional, normalized to the largest family, so a dominant family reads as a "sun" and the rest as smaller "planets".
- Declutter: bubbles and labels fade by on-screen size, so small/distant families drop away and only prominent ones stay labelled when zoomed out.
- Look & feel: glassy MeshPhysical bubbles matching the node material, with a hover grow/brighten + pointer cursor.
- Crossfade individuals <-> clusters with hysteresis; click a bubble to fly in.

Pure helpers (sizing, declutter, crossfade) live in clusterBubbles.ts with unit tests; the live Three.js layer is the useClusterBubbles hook.