### PR TITLE
fix(3d): size cluster bubbles relative to graph radius + guarantee no…

### DIFF
--- a/src/hooks/useClusterBubbles.ts
+++ b/src/hooks/useClusterBubbles.ts
@@ -7,10 +7,12 @@ import {
   computeVisibleBounds,
   computeClusterCentroids,
   bubbleRadius,
+  capRadiiToNeighbors,
   detailFactor,
   apparentDiameterFraction,
   ramp01,
   EXIT_MULT,
+  MIN_BUBBLE_RADIUS_FRAC,
   BUBBLE_FADE_MIN,
   BUBBLE_FADE_FULL,
   LABEL_FADE_MIN,
@@ -173,8 +175,19 @@ export function useClusterBubbles(params: {
 
       if (t <= 0.001) return;
 
-      for (const [cluster, agg] of centroids) {
-        if (!visible.has(cluster)) continue;
+      // Size each visible bubble relative to the graph's extent (so it stays
+      // proportional whether the tree has few or many nodes), then cap it against
+      // its nearest neighbour so intermarried families never mesh into one blob.
+      const graphRadius = boundsRef.current.radius;
+      const visEntries = Array.from(centroids).filter(([cluster]) => visible.has(cluster));
+      const radii = capRadiiToNeighbors(
+        visEntries.map(([, agg]) => agg.centroid),
+        visEntries.map(([, agg]) => bubbleRadius(agg.count, maxCount, graphRadius)),
+        MIN_BUBBLE_RADIUS_FRAC * graphRadius,
+      );
+
+      for (let i = 0; i < visEntries.length; i++) {
+        const [cluster, agg] = visEntries[i];
 
         let bubble = bubbles.get(cluster);
         if (!bubble) {
@@ -184,7 +197,7 @@ export function useClusterBubbles(params: {
         }
 
         bubble.group.position.set(agg.centroid.x, agg.centroid.y, agg.centroid.z);
-        const radius = bubbleRadius(agg.count, maxCount);
+        const radius = radii[i];
 
         // Hover (LIN-32 #4): ease toward the target each frame, then grow & brighten.
         bubble.hoverAmt += (bubble.hoverTarget - bubble.hoverAmt) * HOVER_LERP;

--- a/src/utils/clusterBubbles.test.ts
+++ b/src/utils/clusterBubbles.test.ts
@@ -3,14 +3,16 @@ import {
   computeVisibleBounds,
   computeClusterCentroids,
   bubbleRadius,
+  capRadiiToNeighbors,
   detailFactor,
   apparentDiameterFraction,
   ramp01,
   type LiveNode,
   ENTER_MULT,
   EXIT_MULT,
-  MIN_BUBBLE_RADIUS,
-  MAX_BUBBLE_RADIUS,
+  MIN_BUBBLE_RADIUS_FRAC,
+  MAX_BUBBLE_RADIUS_FRAC,
+  BUBBLE_NEIGHBOR_FRACTION,
 } from './clusterBubbles';
 
 describe('computeVisibleBounds', () => {
@@ -87,29 +89,82 @@ describe('computeClusterCentroids', () => {
 });
 
 describe('bubbleRadius', () => {
-  it('sizes the largest cluster as the full "sun"', () => {
-    expect(bubbleRadius(405, 405)).toBe(MAX_BUBBLE_RADIUS);
-    expect(bubbleRadius(7, 7)).toBe(MAX_BUBBLE_RADIUS);
+  const R = 1000; // graph bounding radius
+
+  it('sizes the largest cluster as the full "sun" (fraction of graph radius)', () => {
+    expect(bubbleRadius(405, 405, R)).toBeCloseTo(MAX_BUBBLE_RADIUS_FRAC * R);
+    expect(bubbleRadius(7, 7, R)).toBeCloseTo(MAX_BUBBLE_RADIUS_FRAC * R);
   });
 
-  it('floors tiny / empty clusters at the minimum', () => {
-    expect(bubbleRadius(1, 405)).toBe(MIN_BUBBLE_RADIUS);
-    expect(bubbleRadius(0, 405)).toBe(MIN_BUBBLE_RADIUS);
+  it('floors tiny / empty clusters at the minimum fraction', () => {
+    expect(bubbleRadius(1, 405, R)).toBeCloseTo(MIN_BUBBLE_RADIUS_FRAC * R);
+    expect(bubbleRadius(0, 405, R)).toBeCloseTo(MIN_BUBBLE_RADIUS_FRAC * R);
+  });
+
+  it('scales with the graph radius (so few-node and many-node trees look alike)', () => {
+    expect(bubbleRadius(405, 405, 2000)).toBeCloseTo(2 * bubbleRadius(405, 405, 1000));
+    expect(bubbleRadius(0, 405, 0)).toBe(0); // degenerate graph → no bubble
   });
 
   it('grows monotonically with member count for a fixed max', () => {
-    expect(bubbleRadius(200, 405)).toBeGreaterThan(bubbleRadius(20, 405));
-    expect(bubbleRadius(20, 405)).toBeGreaterThanOrEqual(bubbleRadius(5, 405));
+    expect(bubbleRadius(200, 405, R)).toBeGreaterThan(bubbleRadius(20, 405, R));
+    expect(bubbleRadius(20, 405, R)).toBeGreaterThanOrEqual(bubbleRadius(5, 405, R));
   });
 
   it('gives the dominant family a strong size lead ("sun vs planets")', () => {
     // A 405-member family should dwarf a singleton, unlike the old ~2.4x.
-    expect(bubbleRadius(405, 405)).toBeGreaterThanOrEqual(bubbleRadius(1, 405) * 5);
+    expect(bubbleRadius(405, 405, R)).toBeGreaterThanOrEqual(bubbleRadius(1, 405, R) * 5);
   });
 
   it('is area-proportional: 4x the members ≈ 2x the radius', () => {
     // radius ∝ √count, so quadrupling members doubles the radius (above the floor).
-    expect(bubbleRadius(400, 400)).toBeCloseTo(bubbleRadius(100, 400) * 2);
+    expect(bubbleRadius(400, 400, R)).toBeCloseTo(bubbleRadius(100, 400, R) * 2);
+  });
+});
+
+describe('capRadiiToNeighbors', () => {
+  const O = { x: 0, y: 0, z: 0 };
+
+  it('leaves bubbles that are already comfortably apart untouched', () => {
+    const centroids = [{ x: 0, y: 0, z: 0 }, { x: 1000, y: 0, z: 0 }];
+    const desired = [50, 50]; // 50 + 50 << 1000 apart → no overlap
+    expect(capRadiiToNeighbors(centroids, desired, 5)).toEqual([50, 50]);
+  });
+
+  it('shrinks overlapping bubbles so the pair no longer meshes', () => {
+    const centroids = [{ x: 0, y: 0, z: 0 }, { x: 100, y: 0, z: 0 }];
+    const desired = [400, 400]; // would massively overlap
+    const [a, b] = capRadiiToNeighbors(centroids, desired, 1);
+    expect(a).toBeCloseTo(BUBBLE_NEIGHBOR_FRACTION * 100);
+    expect(a + b).toBeLessThan(100); // sum < centre distance ⇒ a real gap
+  });
+
+  it('never lets any pair overlap, even in a close cluster of families', () => {
+    const centroids = [
+      { x: 0, y: 0, z: 0 },
+      { x: 60, y: 0, z: 0 },
+      { x: 0, y: 80, z: 0 },
+      { x: 50, y: 50, z: 0 },
+    ];
+    const desired = [300, 300, 300, 300];
+    const r = capRadiiToNeighbors(centroids, desired, 1);
+    for (let i = 0; i < centroids.length; i++) {
+      for (let j = i + 1; j < centroids.length; j++) {
+        const dx = centroids[i].x - centroids[j].x;
+        const dy = centroids[i].y - centroids[j].y;
+        const d = Math.hypot(dx, dy);
+        expect(r[i] + r[j]).toBeLessThanOrEqual(d + 1e-9);
+      }
+    }
+  });
+
+  it('keeps near-coincident clusters visible via the min floor', () => {
+    const centroids = [O, { x: 1, y: 0, z: 0 }];
+    expect(capRadiiToNeighbors(centroids, [300, 300], 20)).toEqual([20, 20]);
+  });
+
+  it('does not cap a lone bubble (no neighbours)', () => {
+    expect(capRadiiToNeighbors([O], [123], 5)).toEqual([123]);
   });
 });
 

--- a/src/utils/clusterBubbles.ts
+++ b/src/utils/clusterBubbles.ts
@@ -27,12 +27,24 @@ export const ENTER_MULT = 1.5;
 /** Return to full detail once camera distance drops below EXIT_MULT * graphRadius. */
 export const EXIT_MULT = 1.0;
 
-/** Smallest "planet" bubble — small but still visible and clickable. (tunable) */
-export const MIN_BUBBLE_RADIUS = 50;
-/** The dominant "sun" — radius of the single largest cluster. (tunable) */
-export const MAX_BUBBLE_RADIUS = 600;
+// Bubble sizes are expressed as fractions of the graph's bounding radius (NOT
+// absolute world units) so they look the same whether the tree has 50 nodes or
+// 5,000. With absolute sizes, a small (few-node) graph gets bubbles far larger
+// than the layout and they mush together. (tunable)
+/** The dominant "sun" — radius of the single largest cluster, as a fraction of the graph radius. */
+export const MAX_BUBBLE_RADIUS_FRAC = 0.15;
+/** Smallest "planet" bubble, as a fraction of the graph radius (kept visible/clickable). */
+export const MIN_BUBBLE_RADIUS_FRAC = 0.015;
 /** Exponent on a cluster's share of the largest cluster. 0.5 = area-proportional. */
 export const BUBBLE_SIZE_EXPONENT = 0.5;
+/**
+ * A bubble may fill at most this fraction of the distance to its nearest
+ * neighbouring bubble. Must be ≤ 0.5 to guarantee no two bubbles overlap (two
+ * adjacent bubbles then span at most 2×this of the gap between them); below 0.5
+ * leaves a visible gap. This is what stops intermarried families — whose
+ * centroids the force layout pulls close together — from meshing into one blob.
+ */
+export const BUBBLE_NEIGHBOR_FRACTION = 0.46;
 
 // --- Declutter (LIN-32 #3): fade bubbles & labels by their on-screen size, so
 // small/distant families drop away when zoomed out instead of colliding. All are
@@ -136,16 +148,48 @@ export function computeClusterCentroids(
 }
 
 /**
- * World-space radius for a cluster bubble, normalized against the largest
- * cluster (`maxCount`). The size encodes member count by *area*
- * (radius ∝ √count, via BUBBLE_SIZE_EXPONENT) so a dominant family reads like a
- * "sun" at MAX_BUBBLE_RADIUS while the rest shrink to "planets" by the root of
- * their share. Floored at MIN_BUBBLE_RADIUS so small families stay findable.
+ * World-space radius for a cluster bubble, as a fraction of the graph's bounding
+ * radius (`graphRadius`) so bubbles stay proportional to the layout regardless of
+ * node count. Normalized against the largest cluster (`maxCount`) and encoding
+ * member count by *area* (radius ∝ √count, via BUBBLE_SIZE_EXPONENT), so the
+ * dominant family reads like a "sun" at MAX_BUBBLE_RADIUS_FRAC·graphRadius while
+ * the rest shrink to "planets" by the root of their share; floored at
+ * MIN_BUBBLE_RADIUS_FRAC·graphRadius so small families stay findable.
  */
-export function bubbleRadius(count: number, maxCount: number): number {
+export function bubbleRadius(count: number, maxCount: number, graphRadius: number): number {
   const share = Math.max(1, count) / Math.max(1, maxCount); // 0..1
   const frac = Math.pow(share, BUBBLE_SIZE_EXPONENT);
-  return Math.max(MIN_BUBBLE_RADIUS, MAX_BUBBLE_RADIUS * frac);
+  return Math.max(MIN_BUBBLE_RADIUS_FRAC, MAX_BUBBLE_RADIUS_FRAC * frac) * Math.max(0, graphRadius);
+}
+
+/**
+ * Shrink each bubble's `desired` radius just enough that it never reaches its
+ * nearest neighbour — guaranteeing no two bubbles overlap (a no-op for bubbles
+ * already comfortably apart). Each is capped at BUBBLE_NEIGHBOR_FRACTION of the
+ * distance to its closest neighbour, then floored at `minRadius` so near-
+ * coincident clusters stay visible (accepting slight overlap only in that case).
+ */
+export function capRadiiToNeighbors(
+  centroids: ReadonlyArray<Vec3>,
+  desired: ReadonlyArray<number>,
+  minRadius: number
+): number[] {
+  const n = centroids.length;
+  const out = new Array<number>(n);
+  for (let i = 0; i < n; i++) {
+    let nearest = Infinity;
+    for (let j = 0; j < n; j++) {
+      if (j === i) continue;
+      const dx = centroids[i].x - centroids[j].x;
+      const dy = centroids[i].y - centroids[j].y;
+      const dz = centroids[i].z - centroids[j].z;
+      const d = Math.sqrt(dx * dx + dy * dy + dz * dz);
+      if (d < nearest) nearest = d;
+    }
+    const cap = Number.isFinite(nearest) ? BUBBLE_NEIGHBOR_FRACTION * nearest : Infinity;
+    out[i] = Math.max(minRadius, Math.min(desired[i], cap));
+  }
+  return out;
 }
 
 /**


### PR DESCRIPTION
… overlap (LIN-32)

On graphs with few nodes (e.g. production), the cluster bubbles were sized in absolute world units (up to 600) while the whole layout spanned only ~500, so bubbles were larger than the graph and mushed together; you also had to zoom in very far before they expanded back into individuals.

- Size each bubble as a fraction of the graph's bounding radius (MAX_BUBBLE_RADIUS_FRAC) so it stays proportional whether the tree has 50 or 5,000 nodes, instead of absolute MIN/MAX_BUBBLE_RADIUS world units.
- Add capRadiiToNeighbors: cap each bubble at a fraction of the distance to its nearest neighbour, guaranteeing no two bubbles overlap (a no-op when already apart; a min-size floor keeps near-coincident clusters visible).

Verified live against production data (graph radius ~520): bubbles are now clearly separated with the dominant family as a "sun". 28 unit tests.