### PR TITLE
fix(3d): clicking a node no longer fades the whole tree (LIN-52)

### DIFF
--- a/src/components/FamilyTree3D.tsx
+++ b/src/components/FamilyTree3D.tsx
@@ -21,6 +21,7 @@ import { getClusterColors } from '../utils/familyColors';
 import { getNodeId } from '../utils/getNodeId';
 import { filterGraphDataFor3D } from '../lib/filterGraphData';
 import { useClusterBubbles } from '../hooks/useClusterBubbles';
+import { EXIT_MULT } from '../utils/clusterBubbles';
 import { TreeSearchBar } from './TreeSearchBar';
 
 // V3 Shared Assets - paths resolved at runtime for WebP when supported
@@ -382,7 +383,7 @@ export const FamilyTree3DContent: React.FC<FamilyTree3DProps> = ({
   // Family cluster view on zoom-out (LIN-32): fades individuals into per-cluster
   // bubbles when zoomed out. `detailRef` (0..1) drives the node fade below;
   // `fullyClustered` hides individuals/links entirely once fully zoomed out.
-  const { detailRef, fullyClustered } = useClusterBubbles({
+  const { detailRef, fullyClustered, boundsRef } = useClusterBubbles({
     fgRef,
     graphData: filteredGraphData,
     visibleClusters: visibleClusters3D,
@@ -426,8 +427,15 @@ export const FamilyTree3DContent: React.FC<FamilyTree3DProps> = ({
     const z = (typeof nodeData.z === 'number' && !isNaN(nodeData.z)) ? nodeData.z : 0;
     
     const nodePos = { x, y, z };
-    const distance = 120;
-    
+    // Focus distance must stay inside LIN-32's full-detail band. That band is
+    // relative to graph size (detailFactor fades individuals out past
+    // EXIT_MULT * radius), so a fixed distance fades the whole tree to opacity 0
+    // on any graph with radius < ~67. Mirrors focusCluster's clamp.
+    const graphRadius = boundsRef.current.radius;
+    const distance = graphRadius > 0
+      ? Math.max(30, Math.min(120, EXIT_MULT * graphRadius * 0.7))
+      : 120;
+
     const camera = fgRef.current.camera();
     const currentPos = camera.position;
     
@@ -474,7 +482,7 @@ export const FamilyTree3DContent: React.FC<FamilyTree3DProps> = ({
       if (progress < 1) requestAnimationFrame(animate);
     };
     animate();
-  }, [onNodeSelect]);
+  }, [onNodeSelect, boundsRef]);
 
   // Reset View functionality
   const resetView = useCallback(() => {

--- a/src/hooks/useClusterBubbles.ts
+++ b/src/hooks/useClusterBubbles.ts
@@ -59,7 +59,11 @@ export function useClusterBubbles(params: {
   graphData: { nodes: LiveNode[]; links: unknown[] };
   visibleClusters: Set<string>;
   enabled: boolean;
-}): { detailRef: React.MutableRefObject<number>; fullyClustered: boolean } {
+}): {
+  detailRef: React.MutableRefObject<number>;
+  fullyClustered: boolean;
+  boundsRef: React.MutableRefObject<{ centroid: Vec3; radius: number }>;
+} {
   const { fgRef, graphData, visibleClusters, enabled } = params;
 
   const detailRef = useRef(0);
@@ -423,5 +427,5 @@ export function useClusterBubbles(params: {
     };
   }, [fgRef]);
 
-  return { detailRef, fullyClustered };
+  return { detailRef, fullyClustered, boundsRef };
 }


### PR DESCRIPTION
Clicking any node in the 3D view made every planet and link disappear.

## Cause

`handleNodeClick` flew the camera to a hardcoded **120 units** from the clicked node and set `controls.target` to it, so the camera-to-target distance was always 120. LIN-32's cluster aggregation threshold is *relative* to graph size — `detailFactor()` returns 1 once `distance >= ENTER_MULT * radius`. With `ENTER_MULT = 1.8`:

```
120 >= 1.8 × radius   →   radius <= 67
```

Past that, `nodeThreeObject` renders every individual at `opacity = baseOpacity × (1 - detail)` = **0**, and `fullyClustered` hides all links. Partial fading starts below radius 92.

The fixed distance predates LIN-32; `956be7a` raised the multipliers and widened the window where this fires.

## Fix

`useClusterBubbles` already had the right pattern for its own fly-in — `focusCluster` scales to the radius and stays inside the exit band. `boundsRef` even carried the comment *"shared with the click handler for fly-in distance"*; it was just never returned from the hook.

Returns `boundsRef` and clamps the focus distance into the full-detail band.

## Known remaining edge

On a graph with visible radius < ~17 the 30-unit floor still exceeds the threshold. Left alone rather than reshaping LIN-32's thresholds as a drive-by — worth deciding separately whether node focus should be exempt from aggregation entirely.

Found while prototyping LIN-46. Ships independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)