### PR TITLE
feat(tree-3d): Connect Mode with spatial candidate targeting (LIN-50)

### DIFF
--- a/src/components/ConnectTargetingBody.tsx
+++ b/src/components/ConnectTargetingBody.tsx
@@ -1,0 +1,174 @@
+import React from 'react';
+import { FamilyNode } from '../types/graph';
+import { TargetOption } from './cards/connectCandidates';
+import { CONNECT_ACCENT } from './cards/relationStyle';
+
+/**
+ * The body of the docked panel while Connect Mode is aiming (LIN-50).
+ *
+ * The list is the answer to the problem 2D never had: a legitimate target can
+ * be occluded, off-screen or a few pixels wide, so aiming alone would leave
+ * people unlinkable from whatever viewpoint the user happens to be at. It
+ * reuses the existing search result set rather than introducing a second way
+ * to find someone.
+ *
+ * Presentational and unpositioned — the panel places it, and owns none of the
+ * Connect Mode state it displays.
+ */
+export interface ConnectTargetingBodyProps {
+  sourceNode: FamilyNode;
+  /** The rows to offer — already ranked and capped by `buildTargetOptions`. */
+  options: TargetOption[];
+  /** Everyone linkable, which is usually more than the list can hold. */
+  candidateCount: number;
+  /** The whole pool the list was drawn from, before its cap. */
+  optionTotal: number;
+  /** How many of those the camera cannot currently see. */
+  unreachableCount: number;
+  /** The last aim that landed on someone who cannot be a target. */
+  rejected: { node: FamilyNode; reason: string } | null;
+  query: string;
+  onQueryChange?: (query: string) => void;
+  onPickTarget: (node: FamilyNode) => void;
+  onExit: () => void;
+}
+
+export const ConnectTargetingBody: React.FC<ConnectTargetingBodyProps> = ({
+  sourceNode,
+  options,
+  candidateCount,
+  optionTotal,
+  unreachableCount,
+  rejected,
+  query,
+  onQueryChange,
+  onPickTarget,
+  onExit,
+}) => {
+  const truncated = Math.max(0, optionTotal - options.length);
+
+  return (
+    <>
+      <div style={{ fontSize: 11, fontWeight: 700, color: CONNECT_ACCENT }}>
+        🔗 Connect {sourceNode.firstName} to…
+      </div>
+      <div style={{ fontSize: 10, color: 'rgba(255,255,255,0.65)', lineHeight: 1.4 }}>
+        {candidateCount === 0
+          ? 'No one in view can be linked to this person yet.'
+          : 'Click a glowing planet, or pick from the list.'}
+        {unreachableCount > 0 && (
+          <>
+            {' '}
+            <span style={{ color: '#fbbf24' }}>
+              {unreachableCount} of {candidateCount} are out of view — search for them by name.
+            </span>
+          </>
+        )}
+      </div>
+
+      <input
+        value={query}
+        onChange={(e) => onQueryChange?.(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') {
+            e.preventDefault();
+            onExit();
+          }
+        }}
+        placeholder="Search anyone by name…"
+        dir="auto"
+        aria-label="Search for a person to connect"
+        style={{
+          background: 'rgba(0,0,0,0.35)',
+          border: '1px solid rgba(255,255,255,0.15)',
+          borderRadius: 6,
+          color: '#fff',
+          fontSize: 11,
+          outline: 'none',
+          padding: '6px 8px',
+          width: '100%',
+          boxSizing: 'border-box',
+        }}
+      />
+
+      <div
+        style={{ display: 'flex', flexDirection: 'column', gap: 4, maxHeight: 190, overflowY: 'auto' }}
+      >
+        {options.map(({ node, candidacy, visibility }) => (
+          <button
+            key={node.id}
+            type="button"
+            disabled={!candidacy.ok}
+            onClick={() => onPickTarget(node)}
+            title={candidacy.ok ? undefined : candidacy.reason}
+            style={{
+              alignItems: 'center',
+              background: candidacy.ok ? 'rgba(192, 132, 252, 0.12)' : 'rgba(255,255,255,0.03)',
+              border: candidacy.ok
+                ? `1px solid ${CONNECT_ACCENT}66`
+                : '1px solid rgba(255,255,255,0.08)',
+              borderRadius: 6,
+              color: candidacy.ok ? '#fff' : 'rgba(255,255,255,0.35)',
+              cursor: candidacy.ok ? 'pointer' : 'not-allowed',
+              display: 'flex',
+              fontSize: 11,
+              gap: 6,
+              justifyContent: 'space-between',
+              padding: '5px 8px',
+              textAlign: 'left',
+            }}
+          >
+            <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+              {node.firstName}
+              {node.familyCluster && (
+                <span style={{ color: 'rgba(255,255,255,0.4)' }}> · {node.familyCluster}</span>
+              )}
+            </span>
+            {candidacy.ok && visibility !== 'onscreen' && (
+              <span
+                style={{ color: '#fbbf24', flexShrink: 0 }}
+                title={visibility === 'behind' ? 'Behind the camera' : 'Off-screen'}
+              >
+                ↗
+              </span>
+            )}
+          </button>
+        ))}
+        {options.length === 0 && (
+          <div style={{ fontSize: 10, color: 'rgba(255,255,255,0.4)' }}>
+            {query.trim() ? 'No one matches that search.' : 'Nothing to link to here.'}
+          </div>
+        )}
+      </div>
+
+      {/* Saying how many were left out, rather than claiming the list is all of them. */}
+      {truncated > 0 && (
+        <div style={{ fontSize: 10, color: 'rgba(255,255,255,0.4)' }}>
+          {truncated} more — narrow it with a search.
+        </div>
+      )}
+
+      {rejected && (
+        <div style={{ fontSize: 10, color: '#f87171', lineHeight: 1.4 }}>
+          {rejected.node.firstName}: {rejected.reason}
+        </div>
+      )}
+
+      <button
+        type="button"
+        onClick={onExit}
+        style={{
+          background: 'transparent',
+          border: '1px solid rgba(255,255,255,0.2)',
+          borderRadius: 6,
+          color: 'rgba(255,255,255,0.8)',
+          cursor: 'pointer',
+          fontSize: 11,
+          padding: '5px 8px',
+        }}
+      >
+        Cancel (Esc)
+      </button>
+    </>
+  );
+};

--- a/src/components/FamilyTree.tsx
+++ b/src/components/FamilyTree.tsx
@@ -671,6 +671,7 @@ export const FamilyTree: React.FC = () => {
             canEditSelected={canEditSelected}
             onCreateRelative={handleCreateRelativeDirect}
             onConnectExistingRelative={handleConnectExistingRelativeDirect}
+            onDirectConnectNodes={handleDirectConnectNodes}
           />
         ) : (
           <FamilyTree2D

--- a/src/components/FamilyTree3D.tsx
+++ b/src/components/FamilyTree3D.tsx
@@ -23,7 +23,16 @@ import { filterGraphDataFor3D } from '../lib/filterGraphData';
 import { useClusterBubbles } from '../hooks/useClusterBubbles';
 import { EXIT_MULT } from '../utils/clusterBubbles';
 import { TreeSearchBar } from './TreeSearchBar';
-import { Manipulation3DPanel } from './Manipulation3DPanel';
+import { Manipulation3DPanel, Connect3DControls } from './Manipulation3DPanel';
+import {
+  Candidacy,
+  ConnectPair,
+  buildCandidacy,
+  candidacyFor,
+  candidateIds,
+} from './cards/connectCandidates';
+import { KinshipLinkType, ParentRole } from './cards/connectOptions';
+import { CONNECT_ACCENT } from './cards/relationStyle';
 
 // V3 Shared Assets - paths resolved at runtime for WebP when supported
 const planetTexturePaths = [
@@ -51,6 +60,17 @@ const planetMaterialCache = new Map<string, THREE.Material>();
 function isPreviewLink(l: { type?: string }): boolean {
   return l.type === 'preview';
 }
+
+/**
+ * Connect Mode candidate affordance (LIN-50). Valid targets are rim-lit in the
+ * picker's own purple; everyone else is dimmed towards the background, so from
+ * a crowded viewpoint the linkable planets are the ones that still read.
+ */
+const CONNECT_ACCENT_3D = new THREE.Color(CONNECT_ACCENT);
+const CONNECT_NON_CANDIDATE_DIM = 0.2;
+/** Shared so that outside Connect Mode the candidacy identity never changes,
+ *  and the scene is not asked to rebuild every node object for nothing. */
+const NO_CANDIDACY: Map<string, Candidacy> = new Map();
 
 const THEME_COLORS_3D: Record<Exclude<BackgroundTheme, 'deep-space'>, number> = {
   'wax-white': 0xfffef8,
@@ -215,6 +235,13 @@ interface FamilyTree3DProps {
     relation: RelativeDirection;
     targetNodeId: string;
   }) => Promise<void> | void;
+  /** Connect Mode (LIN-50): creates the Kinship Link once a pair and kind are chosen. */
+  onDirectConnectNodes?: (params: {
+    sourceNodeId: string;
+    targetNodeId: string;
+    type: 'parent' | 'marriage' | 'divorce';
+    parentRole?: 'mother' | 'father' | null;
+  }) => Promise<void> | void;
 }
 
 export const FamilyTree3DContent: React.FC<FamilyTree3DProps> = ({
@@ -254,6 +281,7 @@ export const FamilyTree3DContent: React.FC<FamilyTree3DProps> = ({
   canEditSelected = false,
   onCreateRelative,
   onConnectExistingRelative,
+  onDirectConnectNodes,
 }) => {
   const ForceGraph3DAny = ForceGraph3D as unknown as React.ComponentType<any>;
   const { userProfile } = useAuth();
@@ -279,6 +307,24 @@ export const FamilyTree3DContent: React.FC<FamilyTree3DProps> = ({
   const envInitializedRef = useRef(false);
   const hasIntroPlayed = useRef(false);
   const rotationRef = useRef(0);
+
+  // Connect Mode (LIN-50): two-click targeting, source first.
+  const [connectSource, setConnectSource] = useState<FamilyNode | null>(null);
+  const [connectPair, setConnectPair] = useState<ConnectPair | null>(null);
+  const [rejectedTarget, setRejectedTarget] = useState<{ node: FamilyNode; reason: string } | null>(
+    null
+  );
+  /**
+   * Mirrors the source id for the graph's click handler.
+   *
+   * `onNodeClick` otherwise always launches a camera fly-to, which would rip
+   * the viewport away the instant a target is clicked. Nothing else holds the
+   * camera still — Manipulation Freeze was dropped after prototyping (ADR 0002)
+   * — so this gate is the whole of that guarantee, and a ref keeps it correct
+   * even if the graph is holding an older handler.
+   */
+  const connectModeRef = useRef<string | null>(null);
+  connectModeRef.current = connectSource?.id ?? null;
 
   // Internal state for modals
   const [initialCameraPos, setInitialCameraPos] = useState<{ x: number; y: number; z: number } | null>(null);
@@ -374,19 +420,31 @@ export const FamilyTree3DContent: React.FC<FamilyTree3DProps> = ({
         uniqueClusters
       );
 
+      // Synthetic dashed edges. Both reuse the same `isPreviewLink` rendering
+      // path, which is also why the Connect Mode beam appears only once a pair
+      // is chosen and not under the pointer: every one of these rebuilds
+      // graphData, and the graph re-runs its warmup ticks when it does.
+      const previewLinks: { source: string; target: string; type: string }[] = [];
+      const bothVisible = (a: string, b: string) =>
+        filtered.nodes.some(n => n.id === a) && filtered.nodes.some(n => n.id === b);
+
       if (pendingLinkPreview) {
         const { anchorId, existingId } = pendingLinkPreview;
-        const anchorVisible = filtered.nodes.some(n => n.id === anchorId);
-        const existingVisible = filtered.nodes.some(n => n.id === existingId);
-        if (anchorVisible && existingVisible) {
-          return {
-            ...filtered,
-            links: [
-              ...filtered.links,
-              { source: anchorId, target: existingId, type: 'preview' },
-            ],
-          };
+        if (bothVisible(anchorId, existingId)) {
+          previewLinks.push({ source: anchorId, target: existingId, type: 'preview' });
         }
+      }
+
+      if (connectPair && bothVisible(connectPair.source.id, connectPair.target.id)) {
+        previewLinks.push({
+          source: connectPair.source.id,
+          target: connectPair.target.id,
+          type: 'preview',
+        });
+      }
+
+      if (previewLinks.length) {
+        return { ...filtered, links: [...filtered.links, ...previewLinks] };
       }
 
       return filtered;
@@ -394,7 +452,27 @@ export const FamilyTree3DContent: React.FC<FamilyTree3DProps> = ({
       console.error('[FamilyTree3D] Error filtering graph data:', err);
       return { nodes: [], links: [] };
     }
-  }, [graphData, effectiveCollapsedNodes, visibleClusters3D, uniqueClusters, pendingLinkPreview]);
+  }, [
+    graphData,
+    effectiveCollapsedNodes,
+    visibleClusters3D,
+    uniqueClusters,
+    pendingLinkPreview,
+    connectPair,
+  ]);
+
+  const connectCandidacy = useMemo<Map<string, Candidacy>>(
+    () =>
+      connectSource
+        ? buildCandidacy(graphData, connectSource.id, filteredGraphData.nodes)
+        : NO_CANDIDACY,
+    [connectSource, graphData, filteredGraphData.nodes]
+  );
+
+  const connectCandidateIds = useMemo(
+    () => candidateIds(connectCandidacy),
+    [connectCandidacy]
+  );
 
   // Family cluster view on zoom-out (LIN-32): fades individuals into per-cluster
   // bubbles when zoomed out. `detailRef` (0..1) drives the node fade below;
@@ -499,6 +577,121 @@ export const FamilyTree3DContent: React.FC<FamilyTree3DProps> = ({
     };
     animate();
   }, [onNodeSelect, boundsRef]);
+
+  const exitConnectMode = useCallback(() => {
+    setConnectSource(null);
+    setConnectPair(null);
+    setRejectedTarget(null);
+  }, []);
+
+  const startConnectMode = useCallback(() => {
+    if (!selectedNode) return;
+    setConnectSource(selectedNode);
+    setConnectPair(null);
+    setRejectedTarget(null);
+  }, [selectedNode]);
+
+  /**
+   * Resolve the second click of the pair.
+   *
+   * A refused target says why rather than doing nothing: in a crowded scene an
+   * inert click is indistinguishable from a miss, and the user would keep
+   * aiming at someone who can never be linked.
+   */
+  const pickConnectTarget = useCallback(
+    (node: FamilyNode) => {
+      const source = connectSource;
+      if (!source) return;
+      if (source.id === node.id) {
+        exitConnectMode();
+        return;
+      }
+      const verdict = candidacyFor(graphData, source.id, node.id);
+      if (!verdict.ok) {
+        setRejectedTarget({ node, reason: verdict.reason });
+        return;
+      }
+      setRejectedTarget(null);
+      setConnectPair({ source, target: node });
+    },
+    [connectSource, graphData, exitConnectMode]
+  );
+
+  const handleGraphNodeClick = useCallback(
+    (node: FamilyNode) => {
+      if (connectModeRef.current) {
+        pickConnectTarget(node);
+        return;
+      }
+      handleNodeClick(node);
+    },
+    [handleNodeClick, pickConnectTarget]
+  );
+
+  const handleConnectConfirm = useCallback(
+    async (type: KinshipLinkType, parentRole?: ParentRole, parentIsSource?: boolean) => {
+      if (!connectPair) return;
+      // The picker may name the target as the parent, which flips the edge.
+      const flipped = type === 'parent' && parentIsSource === false;
+      await Promise.resolve(
+        onDirectConnectNodes?.({
+          sourceNodeId: flipped ? connectPair.target.id : connectPair.source.id,
+          targetNodeId: flipped ? connectPair.source.id : connectPair.target.id,
+          type,
+          parentRole,
+        })
+      );
+      exitConnectMode();
+    },
+    [connectPair, onDirectConnectNodes, exitConnectMode]
+  );
+
+  const handleGraphBackgroundClick = useCallback(() => {
+    if (connectPair) {
+      setConnectPair(null);
+      return;
+    }
+    if (connectSource) {
+      exitConnectMode();
+      return;
+    }
+    onBackgroundClick?.();
+  }, [connectPair, connectSource, exitConnectMode, onBackgroundClick]);
+
+  // Connect Mode is anchored to the selection it started from; if that moves
+  // out from under it the docked panel goes with it, so the state has nothing
+  // left to sit on.
+  useEffect(() => {
+    if (connectSource && selectedNode?.id !== connectSource.id) exitConnectMode();
+  }, [selectedNode, connectSource, exitConnectMode]);
+
+  const connectControls = useMemo<Connect3DControls>(
+    () => ({
+      sourceNode: connectSource,
+      pair: connectPair,
+      candidacy: connectCandidacy,
+      candidateIds: connectCandidateIds,
+      visibleNodes: filteredGraphData.nodes,
+      rejected: rejectedTarget,
+      onStart: startConnectMode,
+      onPickTarget: pickConnectTarget,
+      onCancelPair: () => setConnectPair(null),
+      onExit: exitConnectMode,
+      onConfirm: handleConnectConfirm,
+    }),
+    [
+      connectSource,
+      connectPair,
+      connectCandidacy,
+      connectCandidateIds,
+      filteredGraphData.nodes,
+      rejectedTarget,
+      startConnectMode,
+      pickConnectTarget,
+      exitConnectMode,
+      handleConnectConfirm,
+    ]
+  );
 
   // Reset View functionality
   const resetView = useCallback(() => {
@@ -933,6 +1126,21 @@ export const FamilyTree3DContent: React.FC<FamilyTree3DProps> = ({
           document.activeElement?.tagName === 'INPUT' || 
           document.activeElement?.tagName === 'TEXTAREA') return;
       
+      // Connect Mode is a targeting state: Escape steps back out of it, and the
+      // selection shortcuts are held back so the docked panel cannot be pulled
+      // out from under a half-made link.
+      if (key === 'escape' && connectPair) {
+        e.preventDefault();
+        setConnectPair(null);
+        return;
+      }
+      if (key === 'escape' && connectSource) {
+        e.preventDefault();
+        exitConnectMode();
+        return;
+      }
+      if (connectSource) return;
+
       if (key === 'r') {
         setIsSteeringActive(prev => !prev);
       } else       if (key === 'tab') {
@@ -993,6 +1201,10 @@ export const FamilyTree3DContent: React.FC<FamilyTree3DProps> = ({
     isAddModalOpen,
     isEditModalOpen,
     isBulkInviteOpen,
+    connectSource,
+    connectPair,
+    exitConnectMode,
+    onBackgroundClick,
   ]);
 
   // Node UI
@@ -1003,6 +1215,16 @@ export const FamilyTree3DContent: React.FC<FamilyTree3DProps> = ({
       const colors = getClusterColors(node.familyCluster);
       const color = colors.border;
       const group = new THREE.Group();
+
+      // Connect Mode candidate affordance (LIN-50).
+      const connectSourceId = connectSource?.id ?? null;
+      const isConnectSource = connectSourceId === node.id;
+      const isConnectCandidate =
+        connectSourceId !== null && !isConnectSource && connectCandidateIds.has(node.id);
+      const connectDim =
+        connectSourceId !== null && !isConnectSource && !isConnectCandidate
+          ? CONNECT_NON_CANDIDATE_DIM
+          : 1;
 
       if (nodeTexture !== 'none') {
         const material = nodeTexture === 'planets' ? getPlanetMaterial(node.id, isMob) : getMaterial(color, isMob);
@@ -1018,9 +1240,11 @@ export const FamilyTree3DContent: React.FC<FamilyTree3DProps> = ({
           const rot = rotationRef.current * speedFactor;
           sphere.rotation.y = rot;
           sphere.rotation.z = rot * 0.5;
-          // Crossfade individuals out as cluster bubbles fade in (LIN-32).
+          // Crossfade individuals out as cluster bubbles fade in (LIN-32), and
+          // sink anyone who cannot be a Connect Mode target (LIN-50).
           material.transparent = true;
-          material.opacity = material.userData.baseOpacity * (1 - detailRef.current);
+          material.opacity =
+            material.userData.baseOpacity * (1 - detailRef.current) * connectDim;
         };
 
         if (isSelected) {
@@ -1033,6 +1257,33 @@ export const FamilyTree3DContent: React.FC<FamilyTree3DProps> = ({
           const searchGlow = new THREE.Mesh(geometries.glow, new THREE.MeshBasicMaterial({ color: 0xef4444, transparent: true, opacity: 0.55 }));
           group.add(searchGlow);
         }
+      }
+
+      // Outside the texture check: with textures off there is no sphere to dim,
+      // so the rim is the only thing telling a candidate from the rest.
+      const addConnectShell = (geometry: THREE.BufferGeometry, opacity: number, wireframe = false) => {
+        const material = new THREE.MeshBasicMaterial({
+          color: CONNECT_ACCENT_3D,
+          transparent: true,
+          opacity,
+          wireframe,
+        });
+        const shell = new THREE.Mesh(geometry, material);
+        // Fades with its planet as the cluster bubbles take over (LIN-32);
+        // a rim still burning over a faded-out tree would read as a bug.
+        shell.onBeforeRender = () => {
+          material.opacity = opacity * (1 - detailRef.current);
+        };
+        group.add(shell);
+      };
+
+      if (isConnectCandidate) {
+        addConnectShell(geometries.aura, 0.6, true);
+        addConnectShell(geometries.glow, 0.18);
+      }
+
+      if (isConnectSource) {
+        addConnectShell(geometries.glow, 0.35);
       }
 
       if (showNames) {
@@ -1061,7 +1312,7 @@ export const FamilyTree3DContent: React.FC<FamilyTree3DProps> = ({
         sprite.material.transparent = true;
         // Fade the label together with its sphere when zooming out (LIN-32).
         sprite.onBeforeRender = () => {
-          sprite.material.opacity = 1 - detailRef.current;
+          sprite.material.opacity = (1 - detailRef.current) * connectDim;
         };
         group.add(sprite);
       }
@@ -1071,11 +1322,21 @@ export const FamilyTree3DContent: React.FC<FamilyTree3DProps> = ({
       console.error('[FamilyTree3D] Error in nodeThreeObject:', err);
       return new THREE.Group();
     }
-  }, [selectedNode, showNames, nodeTexture, geometries, rotationRef, searchHighlightedNodeId, detailRef]);
+  }, [
+    selectedNode,
+    showNames,
+    nodeTexture,
+    geometries,
+    rotationRef,
+    searchHighlightedNodeId,
+    detailRef,
+    connectSource,
+    connectCandidateIds,
+  ]);
 
   useEffect(() => {
     if (fgRef.current?.refresh) fgRef.current.refresh();
-  }, [nodeTexture, selectedNode?.id, searchHighlightedNodeId, pendingLinkPreview?.anchorId, pendingLinkPreview?.existingId, showArrows, showLinks]);
+  }, [nodeTexture, selectedNode?.id, searchHighlightedNodeId, pendingLinkPreview?.anchorId, pendingLinkPreview?.existingId, showArrows, showLinks, connectSource, connectCandidateIds]);
 
   // Preview pair framing: one shot after layout; deps = endpoint ids only (no simulation churn).
   useEffect(() => {
@@ -1348,7 +1609,7 @@ export const FamilyTree3DContent: React.FC<FamilyTree3DProps> = ({
         d3VelocityDecay={0.1}
         cooldownTicks={activePreset ? 1000 : 1000}
         onEngineStop={() => setIsSimulationLoading(false)}
-        onNodeClick={(node: FamilyNode) => handleNodeClick(node)}
+        onNodeClick={handleGraphNodeClick}
         onNodeDoubleClick={(node: any) => {
           const nodeId = getNodeId(node);
           if (!nodeId) return;
@@ -1362,7 +1623,7 @@ export const FamilyTree3DContent: React.FC<FamilyTree3DProps> = ({
             effectiveToggleCollapse(nodeId);
           }
         }}
-        onBackgroundClick={onBackgroundClick}
+        onBackgroundClick={handleGraphBackgroundClick}
         linkColor={(l: any) => {
           if (isPreviewLink(l)) return '#22d3ee';
           if (l.type === 'marriage') return '#f59e0b';
@@ -1784,8 +2045,13 @@ export const FamilyTree3DContent: React.FC<FamilyTree3DProps> = ({
         selectedNode={selectedNode}
         canEdit={canEditSelected && !isMobileDevice}
         existingNodes={graphData?.nodes ?? []}
+        graphData={graphData}
         fgRef={fgRef}
         nodes={filteredGraphData.nodes}
+        connect={connectControls}
+        searchQuery={searchQuery}
+        onSearchQueryChange={onSearchQueryChange}
+        searchMatches={searchMatches}
         onCreateRelative={onCreateRelative}
         onConnectExistingRelative={onConnectExistingRelative}
       />

--- a/src/components/Manipulation3DPanel.tsx
+++ b/src/components/Manipulation3DPanel.tsx
@@ -1,10 +1,16 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import * as THREE from 'three';
-import { FamilyNode, RelativeDirection } from '../types/graph';
+import { FamilyGraph, FamilyNode, RelativeDirection } from '../types/graph';
 import { ForceGraphRef, LiveNodePosition } from '../types/forceGraph';
 import { GhostNodeCard, GHOST_CARD_WIDTH } from './cards/GhostNodeCard';
-import { relationColor } from './cards/relationStyle';
+import { ConnectPickerCard, PICKER_CARD_WIDTH } from './cards/ConnectPickerCard';
+import { KinshipLinkType, ParentRole } from './cards/connectOptions';
+import { Candidacy, ConnectPair, buildTargetOptions } from './cards/connectCandidates';
+import { CONNECT_ACCENT, relationColor } from './cards/relationStyle';
+import { ConnectTargetingBody } from './ConnectTargetingBody';
+import { countUnreachable } from '../utils/connectTargeting';
 import { useGhostPreview } from '../hooks/useGhostPreview';
+import { useTargetVisibility } from '../hooks/useTargetVisibility';
 
 /**
  * Docked action panel for the 3D view (LIN-46, ADR 0002).
@@ -21,9 +27,6 @@ import { useGhostPreview } from '../hooks/useGhostPreview';
 
 const PANEL_LEFT = 24;
 const PANEL_PADDING = 12;
-const PANEL_WIDTH = GHOST_CARD_WIDTH + PANEL_PADDING * 2;
-/** Where the leader line meets the panel — derived, so resizing cannot detach it. */
-const PANEL_RIGHT_EDGE = PANEL_LEFT + PANEL_WIDTH;
 
 const HANDLES: { relation: RelativeDirection; label: string }[] = [
   { relation: 'parent', label: '+ Parent' },
@@ -31,14 +34,54 @@ const HANDLES: { relation: RelativeDirection; label: string }[] = [
   { relation: 'spouse', label: '+ Spouse' },
 ];
 
+/**
+ * Connect Mode as the panel sees it (LIN-50).
+ *
+ * The state itself lives in the host, because the scene needs it too: it rim-
+ * lights candidates, gates the camera fly-to on a target click, and draws the
+ * tractor beam. The panel owns none of it and only offers the hit targets.
+ */
+export interface Connect3DControls {
+  /** Who the link is being drawn from; null when Connect Mode is off. */
+  sourceNode: FamilyNode | null;
+  /** Both ends, once a target has been resolved. */
+  pair: ConnectPair | null;
+  /** Verdict per person currently in the scene. */
+  candidacy: Map<string, Candidacy>;
+  /** The accepted ids, already derived by the scene for its rim-lighting. */
+  candidateIds: Set<string>;
+  /** Everyone drawn in the scene — the pool offered when nothing is typed. */
+  visibleNodes: FamilyNode[];
+  /** The last aim that landed on someone who cannot be a target. */
+  rejected: { node: FamilyNode; reason: string } | null;
+  onStart: () => void;
+  onPickTarget: (node: FamilyNode) => void;
+  /** Drop the chosen pair, returning to targeting. */
+  onCancelPair: () => void;
+  /** Leave Connect Mode entirely. */
+  onExit: () => void;
+  onConfirm: (
+    type: KinshipLinkType,
+    parentRole?: ParentRole,
+    parentIsSource?: boolean
+  ) => Promise<void> | void;
+}
+
 export interface Manipulation3DPanelProps {
   selectedNode: FamilyNode | null;
   /** Action Handles appear only when the active user may edit this person. */
   canEdit: boolean;
   existingNodes: FamilyNode[];
+  graphData: FamilyGraph;
   fgRef: ForceGraphRef;
   /** Live simulated nodes — the array handed to the graphData prop. */
   nodes: LiveNodePosition[];
+  connect: Connect3DControls;
+  /** The existing search query, reused as the fallback target filter. */
+  searchQuery: string;
+  onSearchQueryChange?: (query: string) => void;
+  /** The existing `TreeSearchBar` result set. */
+  searchMatches: FamilyNode[];
   onCreateRelative?: (params: {
     firstName: string;
     relation: RelativeDirection;
@@ -64,7 +107,10 @@ const AnchorLeaderLine: React.FC<{
   nodes: LiveNodePosition[];
   nodeId: string;
   color: string;
-}> = ({ fgRef, nodes, nodeId, color }) => {
+  /** Where the line meets the panel — derived by the caller from the panel's
+   *  own width, so widening the panel for a card cannot detach it. */
+  panelRightEdge: number;
+}> = ({ fgRef, nodes, nodeId, color, panelRightEdge }) => {
   const [screen, setScreen] = useState<{ x: number; y: number } | null>(null);
 
   // Read through a ref so a new array identity does not restart the loop.
@@ -115,7 +161,7 @@ const AnchorLeaderLine: React.FC<{
       <line
         x1={screen.x}
         y1={screen.y}
-        x2={PANEL_RIGHT_EDGE}
+        x2={panelRightEdge}
         y2="50%"
         stroke={color}
         strokeWidth={1.5}
@@ -139,8 +185,13 @@ export const Manipulation3DPanel: React.FC<Manipulation3DPanelProps> = ({
   selectedNode,
   canEdit,
   existingNodes,
+  graphData,
   fgRef,
   nodes,
+  connect,
+  searchQuery,
+  onSearchQueryChange,
+  searchMatches,
   onCreateRelative,
   onConnectExistingRelative,
 }) => {
@@ -149,6 +200,7 @@ export const Manipulation3DPanel: React.FC<Manipulation3DPanelProps> = ({
 
   const selectedId = selectedNode?.id ?? null;
   const visible = Boolean(selectedNode && canEdit);
+  const isTargeting = Boolean(connect.sourceNode && !connect.pair);
 
   useGhostPreview({
     fgRef,
@@ -158,6 +210,34 @@ export const Manipulation3DPanel: React.FC<Manipulation3DPanelProps> = ({
     name: previewName,
     enabled: visible,
   });
+
+  const visibility = useTargetVisibility({
+    fgRef,
+    nodes,
+    targetIds: connect.candidateIds,
+    enabled: isTargeting,
+  });
+
+  const { options: targetOptions, total: targetOptionTotal } = useMemo(
+    () =>
+      connect.sourceNode
+        ? buildTargetOptions({
+            query: searchQuery,
+            matches: searchMatches,
+            visibleNodes: connect.visibleNodes,
+            sourceId: connect.sourceNode.id,
+            candidacy: connect.candidacy,
+            visibility,
+          })
+        : { options: [], total: 0 },
+    [connect.sourceNode, connect.candidacy, connect.visibleNodes, searchQuery, searchMatches, visibility]
+  );
+
+  // Before the first sample every candidate reads as unreachable, which would
+  // flash a misleading hint; say nothing until the scene has been measured.
+  const unreachableCount = visibility.size
+    ? countUnreachable([...connect.candidateIds].map((id) => visibility.get(id) ?? 'offscreen'))
+    : 0;
 
   // Abandon any in-flight action when the selection moves elsewhere.
   useEffect(() => {
@@ -192,13 +272,33 @@ export const Manipulation3DPanel: React.FC<Manipulation3DPanelProps> = ({
     [selectedId, relation, onConnectExistingRelative, closeGhostNode]
   );
 
+  const startConnect = useCallback(() => {
+    closeGhostNode();
+    connect.onStart();
+  }, [closeGhostNode, connect]);
+
   if (!selectedNode || !canEdit) return null;
 
-  const accent = relation ? relationColor(relation) : '#a78bfa';
+  const inConnectMode = Boolean(connect.sourceNode);
+  const accent = inConnectMode
+    ? CONNECT_ACCENT
+    : relation
+      ? relationColor(relation)
+      : '#a78bfa';
+
+  // The kinship picker is wider than the Ghost Node card, so the panel takes
+  // whichever card it is currently holding.
+  const panelWidth = (connect.pair ? PICKER_CARD_WIDTH : GHOST_CARD_WIDTH) + PANEL_PADDING * 2;
 
   return (
     <>
-      <AnchorLeaderLine fgRef={fgRef} nodes={nodes} nodeId={selectedNode.id} color={accent} />
+      <AnchorLeaderLine
+        fgRef={fgRef}
+        nodes={nodes}
+        nodeId={connect.sourceNode?.id ?? selectedNode.id}
+        color={accent}
+        panelRightEdge={PANEL_LEFT + panelWidth}
+      />
 
       <div
         style={{
@@ -207,7 +307,7 @@ export const Manipulation3DPanel: React.FC<Manipulation3DPanelProps> = ({
           top: '50%',
           transform: 'translateY(-50%)',
           zIndex: 1250,
-          width: PANEL_WIDTH,
+          width: panelWidth,
           boxSizing: 'border-box',
           background: 'rgba(15, 23, 42, 0.95)',
           backdropFilter: 'blur(16px)',
@@ -232,20 +332,39 @@ export const Manipulation3DPanel: React.FC<Manipulation3DPanelProps> = ({
             whiteSpace: 'nowrap',
           }}
         >
-          {selectedNode.firstName}
+          {connect.sourceNode?.firstName ?? selectedNode.firstName}
         </div>
 
-        {!relation &&
-          HANDLES.map(({ relation: rel, label }) => (
+        {!relation && !inConnectMode && (
+          <>
+            {HANDLES.map(({ relation: rel, label }) => (
+              <button
+                key={rel}
+                type="button"
+                onClick={() => setRelation(rel)}
+                style={{
+                  background: 'rgba(15, 23, 42, 0.92)',
+                  border: `1.5px solid ${relationColor(rel)}`,
+                  borderRadius: 999,
+                  color: relationColor(rel),
+                  cursor: 'pointer',
+                  fontSize: 11,
+                  fontWeight: 700,
+                  padding: '6px 10px',
+                  textAlign: 'left',
+                }}
+              >
+                {label}
+              </button>
+            ))}
             <button
-              key={rel}
               type="button"
-              onClick={() => setRelation(rel)}
+              onClick={startConnect}
               style={{
                 background: 'rgba(15, 23, 42, 0.92)',
-                border: `1.5px solid ${relationColor(rel)}`,
+                border: `1.5px solid ${CONNECT_ACCENT}`,
                 borderRadius: 999,
-                color: relationColor(rel),
+                color: CONNECT_ACCENT,
                 cursor: 'pointer',
                 fontSize: 11,
                 fontWeight: 700,
@@ -253,11 +372,12 @@ export const Manipulation3DPanel: React.FC<Manipulation3DPanelProps> = ({
                 textAlign: 'left',
               }}
             >
-              {label}
+              🔗 Connect
             </button>
-          ))}
+          </>
+        )}
 
-        {relation && (
+        {relation && !inConnectMode && (
           <GhostNodeCard
             relation={relation}
             anchorNodeId={selectedNode.id}
@@ -267,6 +387,33 @@ export const Manipulation3DPanel: React.FC<Manipulation3DPanelProps> = ({
             onConnectExisting={handleConnectExisting}
             onCancel={closeGhostNode}
             onNameChange={setPreviewName}
+          />
+        )}
+
+        {isTargeting && connect.sourceNode && (
+          <ConnectTargetingBody
+            sourceNode={connect.sourceNode}
+            options={targetOptions}
+            candidateCount={connect.candidateIds.size}
+            optionTotal={targetOptionTotal}
+            unreachableCount={unreachableCount}
+            rejected={connect.rejected}
+            query={searchQuery}
+            onQueryChange={onSearchQueryChange}
+            onPickTarget={connect.onPickTarget}
+            onExit={connect.onExit}
+          />
+        )}
+
+        {connect.pair && (
+          <ConnectPickerCard
+            sourceId={connect.pair.source.id}
+            sourceFirstName={connect.pair.source.firstName}
+            targetId={connect.pair.target.id}
+            targetFirstName={connect.pair.target.firstName}
+            graphData={graphData}
+            onConfirm={connect.onConfirm}
+            onCancel={connect.onCancelPair}
           />
         )}
       </div>

--- a/src/components/cards/connectCandidates.test.ts
+++ b/src/components/cards/connectCandidates.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect } from 'vitest';
+import {
+  candidacyFor,
+  buildCandidacy,
+  candidateIds,
+  buildTargetOptions,
+} from './connectCandidates';
+import { FamilyGraph, FamilyNode } from '../../types/graph';
+import { MSG_DUPLICATE, MSG_SELF } from '../../lib/adminGraphValidation';
+import { TargetVisibility } from '../../utils/connectTargeting';
+
+const graph: FamilyGraph = {
+  nodes: [
+    { id: 'p1', firstName: 'Ahmad' },
+    { id: 'p2', firstName: 'Sara' },
+    { id: 'p3', firstName: 'Ali' },
+    { id: 'p4', firstName: 'Layla' },
+  ],
+  links: [
+    { source: 'p1', target: 'p2', type: 'marriage' },
+    { source: 'p1', target: 'p3', type: 'parent' },
+  ],
+};
+
+describe('candidacyFor', () => {
+  it('accepts two people no link joins yet', () => {
+    expect(candidacyFor(graph, 'p1', 'p4')).toEqual({ ok: true });
+  });
+
+  it('refuses the source itself, so a stray click on the source is not a target', () => {
+    expect(candidacyFor(graph, 'p1', 'p1')).toEqual({ ok: false, reason: MSG_SELF });
+  });
+
+  it('refuses an already-married pair, saying they are already connected', () => {
+    expect(candidacyFor(graph, 'p1', 'p2')).toEqual({ ok: false, reason: MSG_DUPLICATE });
+  });
+
+  it('refuses an existing parent-child pair, saying they are already connected', () => {
+    expect(candidacyFor(graph, 'p1', 'p3')).toEqual({ ok: false, reason: MSG_DUPLICATE });
+  });
+
+  it('accepts a pair only one of the four relationships could join', () => {
+    // Siblings: neither parent direction is allowed, but a partnership is.
+    const siblings: FamilyGraph = {
+      ...graph,
+      links: [...graph.links, { source: 'p1', target: 'p4', type: 'parent' }],
+    };
+    expect(candidacyFor(siblings, 'p3', 'p4')).toEqual({ ok: true });
+  });
+
+  it('is symmetric — aiming from either end offers the same pair', () => {
+    expect(candidacyFor(graph, 'p4', 'p2').ok).toBe(candidacyFor(graph, 'p2', 'p4').ok);
+    expect(candidacyFor(graph, 'p1', 'p2').ok).toBe(candidacyFor(graph, 'p2', 'p1').ok);
+  });
+
+  it('always gives a reason when it refuses, so bad aim is distinguishable from a bad target', () => {
+    const refusal = candidacyFor(graph, 'p1', 'p2');
+    expect(refusal.ok).toBe(false);
+    if (!refusal.ok) expect(refusal.reason.length).toBeGreaterThan(0);
+  });
+
+  it('ignores the parent role, which the kinship picker asks for only after a pair is chosen', () => {
+    // p3 already has p1 as a role-less parent; a second parent is still offerable.
+    expect(candidacyFor(graph, 'p4', 'p3')).toEqual({ ok: true });
+  });
+});
+
+describe('buildCandidacy', () => {
+  it('judges every node handed to it, including the source', () => {
+    const candidacy = buildCandidacy(graph, 'p1', graph.nodes);
+    expect([...candidacy.keys()].sort()).toEqual(['p1', 'p2', 'p3', 'p4']);
+    expect(candidacy.get('p1')).toEqual({ ok: false, reason: MSG_SELF });
+    expect(candidacy.get('p4')).toEqual({ ok: true });
+  });
+
+  it('judges only the nodes handed to it, so a hidden cluster is never targetable', () => {
+    const candidacy = buildCandidacy(graph, 'p1', [{ id: 'p4' }]);
+    expect([...candidacy.keys()]).toEqual(['p4']);
+  });
+});
+
+describe('candidateIds', () => {
+  it('keeps the accepted ids only', () => {
+    const ids = candidateIds(buildCandidacy(graph, 'p1', graph.nodes));
+    expect(ids.has('p4')).toBe(true);
+    expect(ids.has('p1')).toBe(false);
+    expect(ids.has('p2')).toBe(false);
+    expect(ids.has('p3')).toBe(false);
+  });
+
+  it('is empty when nothing can be linked, rather than silently offering everything', () => {
+    const pair: FamilyGraph = {
+      nodes: [{ id: 'a', firstName: 'A' }, { id: 'b', firstName: 'B' }],
+      links: [{ source: 'a', target: 'b', type: 'marriage' }],
+    };
+    expect(candidateIds(buildCandidacy(pair, 'a', pair.nodes)).size).toBe(0);
+  });
+});
+
+describe('buildTargetOptions', () => {
+  const visibleNodes: FamilyNode[] = graph.nodes;
+  const candidacy = buildCandidacy(graph, 'p1', visibleNodes);
+
+  const visibility = (overrides: Record<string, TargetVisibility> = {}) =>
+    new Map<string, TargetVisibility>([
+      ['p1', 'onscreen'],
+      ['p2', 'onscreen'],
+      ['p3', 'onscreen'],
+      ['p4', 'onscreen'],
+      ...Object.entries(overrides),
+    ] as [string, TargetVisibility][]);
+
+  const options = (over: Partial<Parameters<typeof buildTargetOptions>[0]> = {}) =>
+    buildTargetOptions({
+      query: '',
+      matches: [],
+      visibleNodes,
+      sourceId: 'p1',
+      candidacy,
+      visibility: visibility(),
+      ...over,
+    });
+
+  it('offers only linkable people when nothing has been typed', () => {
+    expect(options().options.map((o) => o.node.id)).toEqual(['p4']);
+  });
+
+  it('never offers the source, whatever the search says', () => {
+    const rows = options({ query: 'a', matches: [graph.nodes[0], graph.nodes[3]] });
+    expect(rows.options.map((o) => o.node.id)).not.toContain('p1');
+  });
+
+  it('uses the typed search result set verbatim, so a specific person can be looked up', () => {
+    const rows = options({ query: 'sara', matches: [graph.nodes[1]] });
+    expect(rows.options.map((o) => o.node.id)).toEqual(['p2']);
+  });
+
+  it('keeps unlinkable search results, with the reason, rather than hiding them', () => {
+    const rows = options({ query: 'sara', matches: [graph.nodes[1]] });
+    expect(rows.options[0].candidacy).toEqual({ ok: false, reason: MSG_DUPLICATE });
+  });
+
+  it('puts linkable people above unlinkable ones', () => {
+    const rows = options({ query: 'a', matches: [graph.nodes[1], graph.nodes[3]] });
+    expect(rows.options.map((o) => o.node.id)).toEqual(['p4', 'p2']);
+  });
+
+  it('lifts targets aiming cannot reach to the top — they are why the picker exists', () => {
+    const spread: FamilyGraph = { nodes: [...graph.nodes, { id: 'p5', firstName: 'Nour' }], links: graph.links };
+    const rows = buildTargetOptions({
+      query: '',
+      matches: [],
+      visibleNodes: spread.nodes,
+      sourceId: 'p1',
+      candidacy: buildCandidacy(spread, 'p1', spread.nodes),
+      visibility: visibility({ p5: 'behind' }),
+    });
+    expect(rows.options.map((o) => o.node.id)).toEqual(['p5', 'p4']);
+  });
+
+  it('treats an unmeasured target as off-screen rather than dropping it', () => {
+    const rows = options({ visibility: new Map() });
+    expect(rows.options.map((o) => o.node.id)).toEqual(['p4']);
+    expect(rows.options[0].visibility).toBe('offscreen');
+  });
+
+  it('caps the list so the docked panel cannot overrun the viewport', () => {
+    const many: FamilyNode[] = Array.from({ length: 30 }, (_, i) => ({
+      id: `n${i}`,
+      firstName: `N${i}`,
+    }));
+    const bigGraph: FamilyGraph = { nodes: [{ id: 'p1', firstName: 'Ahmad' }, ...many], links: [] };
+    const rows = buildTargetOptions({
+      query: '',
+      matches: [],
+      visibleNodes: bigGraph.nodes,
+      sourceId: 'p1',
+      candidacy: buildCandidacy(bigGraph, 'p1', bigGraph.nodes),
+      visibility: new Map(),
+      limit: 5,
+    });
+    expect(rows.options).toHaveLength(5);
+  });
+
+  it('reports the whole pool, so the panel can admit what the cap left out', () => {
+    const many: FamilyNode[] = Array.from({ length: 12 }, (_, i) => ({
+      id: `n${i}`,
+      firstName: `N${i}`,
+    }));
+    const bigGraph: FamilyGraph = { nodes: [{ id: 'p1', firstName: 'Ahmad' }, ...many], links: [] };
+    const rows = buildTargetOptions({
+      query: '',
+      matches: [],
+      visibleNodes: bigGraph.nodes,
+      sourceId: 'p1',
+      candidacy: buildCandidacy(bigGraph, 'p1', bigGraph.nodes),
+      visibility: new Map(),
+      limit: 5,
+    });
+    expect(rows.total).toBe(12);
+    expect(rows.options).toHaveLength(5);
+  });
+});

--- a/src/components/cards/connectCandidates.ts
+++ b/src/components/cards/connectCandidates.ts
@@ -1,0 +1,136 @@
+import { FamilyGraph, FamilyNode } from '../../types/graph';
+import { MSG_DUPLICATE } from '../../lib/adminGraphValidation';
+import { TargetVisibility } from '../../utils/connectTargeting';
+import { buildConnectOptions } from './connectOptions';
+
+/**
+ * Who can be the target of a Connect Mode link, and why not when they cannot.
+ *
+ * In 2D a rejected pair is discovered late — you click two cards and the picker
+ * greys out every option. In 3D that failure mode is far worse: a target may be
+ * occluded, off-screen, or a few pixels wide, so a click that does nothing is
+ * indistinguishable from bad aim. Deciding candidacy up front is what lets the
+ * scene rim-light the valid targets and name the reason for the rest (LIN-50).
+ */
+
+export type Candidacy = { ok: true } | { ok: false; reason: string };
+
+/** The two ends of a Kinship Link being drawn, in the order they were aimed at. */
+export interface ConnectPair {
+  source: FamilyNode;
+  target: FamilyNode;
+}
+
+export const MSG_TARGET_NOT_IN_VIEW = 'This person is not in the current view.';
+
+/**
+ * Whether any Kinship Link at all could join these two people.
+ *
+ * The role is deliberately left null: which role a parent link carries is asked
+ * for by the kinship picker *after* a pair is chosen, and demanding one here
+ * would hide people who can still be linked some other way.
+ */
+export function candidacyFor(
+  graphData: FamilyGraph,
+  sourceId: string,
+  targetId: string
+): Candidacy {
+  const options = buildConnectOptions(graphData, sourceId, targetId, null);
+  const outcomes = [options.marriage, options.divorce, options.sourceParent, options.targetParent];
+
+  if (outcomes.some((o) => o.ok)) return { ok: true };
+
+  // Every offer failed, so the four messages must be summarised into one. An
+  // existing link between the pair is the fact that explains all four, so it
+  // wins; otherwise the first refusal is as good a summary as any.
+  const refusals = outcomes.flatMap((o) => (o.ok ? [] : [o.message]));
+  return { ok: false, reason: refusals.find((m) => m === MSG_DUPLICATE) ?? refusals[0] };
+}
+
+/**
+ * Judge a whole set of people at once.
+ *
+ * Pass only the people currently in the scene: a hidden cluster is not a
+ * legitimate target, and rim-lighting cannot advertise what is not drawn.
+ */
+export function buildCandidacy(
+  graphData: FamilyGraph,
+  sourceId: string,
+  nodes: { id: string }[]
+): Map<string, Candidacy> {
+  return new Map(nodes.map((node) => [node.id, candidacyFor(graphData, sourceId, node.id)]));
+}
+
+/** The accepted ids, for the per-frame lookups the scene does while rendering. */
+export function candidateIds(candidacy: Map<string, Candidacy>): Set<string> {
+  const ids = new Set<string>();
+  for (const [id, verdict] of candidacy) {
+    if (verdict.ok) ids.add(id);
+  }
+  return ids;
+}
+
+export interface TargetOption {
+  node: FamilyNode;
+  candidacy: Candidacy;
+  visibility: TargetVisibility;
+}
+
+/** Most rows the fallback picker shows at once, so it cannot overrun the panel. */
+export const TARGET_OPTION_LIMIT = 8;
+
+/**
+ * The rows of the fallback picker — the way to reach a target that aiming
+ * cannot.
+ *
+ * Two pools, because the user is asking two different questions. Having typed a
+ * name they mean *that person*, so the existing search result set is offered
+ * verbatim, unlinkable people included with their reason; a silent omission
+ * would read as a broken search. Having typed nothing they mean "who can I even
+ * link to", so only linkable people are listed, unreachable ones first — those
+ * are the ones the picker exists for.
+ */
+export function buildTargetOptions(params: {
+  query: string;
+  /** The existing `TreeSearchBar` result set. */
+  matches: FamilyNode[];
+  /** Everyone currently drawn in the scene. */
+  visibleNodes: FamilyNode[];
+  sourceId: string;
+  candidacy: Map<string, Candidacy>;
+  visibility: Map<string, TargetVisibility>;
+  limit?: number;
+  /** `total` is the whole pool before the cap, so the panel can admit what it left out. */
+}): { options: TargetOption[]; total: number } {
+  const { query, matches, visibleNodes, sourceId, candidacy, visibility } = params;
+  const limit = params.limit ?? TARGET_OPTION_LIMIT;
+
+  // Anyone absent from the candidacy map is not in the scene — a hidden cluster
+  // or a stale search result — and is not linkable from here.
+  const verdictFor = (id: string): Candidacy =>
+    candidacy.get(id) ?? { ok: false, reason: MSG_TARGET_NOT_IN_VIEW };
+
+  const pool = query.trim()
+    ? matches
+    : visibleNodes.filter((node) => verdictFor(node.id).ok);
+
+  const ranked = pool
+    .filter((node) => node.id !== sourceId)
+    .map((node) => ({
+      node,
+      candidacy: verdictFor(node.id),
+      // An unmeasured candidate is treated as unreachable rather than dropped:
+      // the picker is the safe side to err on.
+      visibility: visibility.get(node.id) ?? 'offscreen',
+    }))
+    .sort((a, b) => rank(a) - rank(b));
+
+  return { options: ranked.slice(0, limit), total: ranked.length };
+}
+
+/** Linkable before unlinkable; within each, the ones aiming cannot reach first. */
+function rank(option: TargetOption): number {
+  const linkable = option.candidacy.ok ? 0 : 2;
+  const reachable = option.visibility === 'onscreen' ? 1 : 0;
+  return linkable + reachable;
+}

--- a/src/components/cards/relationStyle.ts
+++ b/src/components/cards/relationStyle.ts
@@ -11,6 +11,13 @@ const RELATION_COLORS: Record<RelativeDirection, string> = {
   child: '#93c5fd',
 };
 
+/**
+ * Connect Mode's own accent, kept beside the relation colours because it plays
+ * the same role: the 2D HUD, the kinship picker, the docked targeting panel and
+ * the 3D candidate rim-light all have to agree on one purple.
+ */
+export const CONNECT_ACCENT = '#c084fc';
+
 export function relationColor(relation: RelativeDirection): string {
   return RELATION_COLORS[relation];
 }

--- a/src/hooks/useTargetVisibility.ts
+++ b/src/hooks/useTargetVisibility.ts
@@ -1,0 +1,97 @@
+import { useEffect, useRef, useState } from 'react';
+import * as THREE from 'three';
+import { ForceGraphRef, LiveNodePosition } from '../types/forceGraph';
+import { classifyTargetVisibility, TargetVisibility } from '../utils/connectTargeting';
+
+/**
+ * Which Connect Mode candidates the camera can currently see (LIN-50).
+ *
+ * The fallback picker needs this to say which targets aiming cannot reach.
+ * Sampled on a timer rather than every frame: the answer only has to be right
+ * enough to badge a list, and re-projecting every candidate at 60fps — then
+ * re-rendering the panel, and with it the text input inside it — would cost far
+ * more than it is worth.
+ */
+
+export const TARGET_VISIBILITY_SAMPLE_MS = 250;
+
+export function useTargetVisibility(params: {
+  fgRef: ForceGraphRef;
+  /** Live simulated nodes — the array handed to the graphData prop. */
+  nodes: LiveNodePosition[];
+  /** Ids to watch; everything else is left unmeasured. */
+  targetIds: Set<string>;
+  enabled: boolean;
+}): Map<string, TargetVisibility> {
+  const { fgRef, nodes, targetIds, enabled } = params;
+  const [visibility, setVisibility] = useState<Map<string, TargetVisibility>>(new Map());
+
+  // Read through refs so a new array or set identity does not restart the loop.
+  const nodesRef = useRef(nodes);
+  nodesRef.current = nodes;
+  const targetIdsRef = useRef(targetIds);
+  targetIdsRef.current = targetIds;
+
+  useEffect(() => {
+    if (!enabled) {
+      setVisibility((prev) => (prev.size === 0 ? prev : new Map()));
+      return;
+    }
+
+    let frameId = 0;
+    let lastSampledAt = -Infinity;
+    const viewSpace = new THREE.Vector3();
+
+    const sample = (now: number) => {
+      frameId = requestAnimationFrame(sample);
+      if (now - lastSampledAt < TARGET_VISIBILITY_SAMPLE_MS) return;
+      lastSampledAt = now;
+
+      const fg = fgRef.current;
+      const project = fg?.graph2ScreenCoords;
+      const camera = fg?.camera?.();
+      const canvas = fg?.renderer?.()?.domElement;
+      if (!project || !camera) return;
+
+      const viewport = {
+        width: canvas?.clientWidth || window.innerWidth,
+        height: canvas?.clientHeight || window.innerHeight,
+      };
+
+      const next = new Map<string, TargetVisibility>();
+      for (const node of nodesRef.current) {
+        if (!targetIdsRef.current.has(node.id)) continue;
+        if (typeof node.x !== 'number' || typeof node.y !== 'number' || typeof node.z !== 'number') {
+          continue;
+        }
+        viewSpace.set(node.x, node.y, node.z).applyMatrix4(camera.matrixWorldInverse);
+        next.set(
+          node.id,
+          classifyTargetVisibility({
+            viewSpaceZ: viewSpace.z,
+            screen: project(node.x, node.y, node.z),
+            viewport,
+          })
+        );
+      }
+
+      setVisibility((prev) => (sameVisibility(prev, next) ? prev : next));
+    };
+
+    frameId = requestAnimationFrame(sample);
+    return () => cancelAnimationFrame(frameId);
+  }, [enabled, fgRef]);
+
+  return visibility;
+}
+
+function sameVisibility(
+  a: Map<string, TargetVisibility>,
+  b: Map<string, TargetVisibility>
+): boolean {
+  if (a.size !== b.size) return false;
+  for (const [id, value] of a) {
+    if (b.get(id) !== value) return false;
+  }
+  return true;
+}

--- a/src/utils/connectTargeting.test.ts
+++ b/src/utils/connectTargeting.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import {
+  classifyTargetVisibility,
+  isBehindCamera,
+  countUnreachable,
+  TARGET_EDGE_MARGIN,
+} from './connectTargeting';
+
+const viewport = { width: 1000, height: 800 };
+
+const at = (x: number, y: number, viewSpaceZ = -500) =>
+  classifyTargetVisibility({ screen: { x, y }, viewSpaceZ, viewport });
+
+describe('classifyTargetVisibility', () => {
+  it('calls a target in the middle of the viewport reachable by aim', () => {
+    expect(at(500, 400)).toBe('onscreen');
+  });
+
+  it('calls a target past the viewport edge off-screen', () => {
+    expect(at(-40, 400)).toBe('offscreen');
+    expect(at(1400, 400)).toBe('offscreen');
+    expect(at(500, -10)).toBe('offscreen');
+    expect(at(500, 900)).toBe('offscreen');
+  });
+
+  it('counts a target hugging the edge as off-screen, where the docked panel and HUD sit', () => {
+    expect(at(TARGET_EDGE_MARGIN / 2, 400)).toBe('offscreen');
+    expect(at(TARGET_EDGE_MARGIN + 1, 400)).toBe('onscreen');
+  });
+
+  it('calls a target behind the camera behind, not off-screen', () => {
+    // three.js cameras look down -Z in view space, so a positive depth is behind.
+    expect(classifyTargetVisibility({ screen: { x: 500, y: 400 }, viewSpaceZ: 120, viewport })).toBe(
+      'behind'
+    );
+  });
+
+  it('trusts depth over the projection, which mirrors a point behind the camera into view', () => {
+    // Screen coordinates alone would read as a perfectly aimable centre-screen hit.
+    expect(classifyTargetVisibility({ screen: { x: 500, y: 400 }, viewSpaceZ: 1, viewport })).toBe(
+      'behind'
+    );
+  });
+
+  it('treats a target exactly on the camera plane as behind, since it cannot be aimed at', () => {
+    expect(classifyTargetVisibility({ screen: { x: 500, y: 400 }, viewSpaceZ: 0, viewport })).toBe(
+      'behind'
+    );
+  });
+
+  it('refuses to guess from a projection that produced no numbers', () => {
+    expect(classifyTargetVisibility({ screen: { x: NaN, y: 400 }, viewSpaceZ: -500, viewport })).toBe(
+      'offscreen'
+    );
+  });
+
+  it('does not call everything off-screen when the viewport has not been measured yet', () => {
+    expect(
+      classifyTargetVisibility({
+        screen: { x: 500, y: 400 },
+        viewSpaceZ: -500,
+        viewport: { width: 0, height: 0 },
+      })
+    ).toBe('offscreen');
+  });
+});
+
+describe('isBehindCamera', () => {
+  it('splits on the camera plane', () => {
+    expect(isBehindCamera(-1)).toBe(false);
+    expect(isBehindCamera(0)).toBe(true);
+    expect(isBehindCamera(1)).toBe(true);
+  });
+});
+
+describe('countUnreachable', () => {
+  it('counts the candidates no amount of aiming can reach', () => {
+    expect(countUnreachable(['onscreen', 'offscreen', 'behind', 'onscreen'])).toBe(2);
+  });
+
+  it('is zero when every candidate is in view, so the hint can stay hidden', () => {
+    expect(countUnreachable(['onscreen', 'onscreen'])).toBe(0);
+    expect(countUnreachable([])).toBe(0);
+  });
+});

--- a/src/utils/connectTargeting.ts
+++ b/src/utils/connectTargeting.ts
@@ -1,0 +1,59 @@
+/**
+ * Where a Connect Mode candidate sits relative to the viewport (LIN-50).
+ *
+ * Raycasting alone is a trap in 3D targeting: a perfectly valid target can be
+ * off-screen, behind the camera, or a few pixels wide, and a click that lands
+ * on nothing looks exactly like a click on an invalid target. Classifying each
+ * candidate lets the fallback picker say which ones aiming cannot reach at all,
+ * so the user knows to pick them from the list instead of hunting for them.
+ *
+ * Deliberately free of three.js types: hosts project the point themselves (the
+ * graph exposes `graph2ScreenCoords`) and hand the numbers over.
+ */
+
+export type TargetVisibility = 'onscreen' | 'offscreen' | 'behind';
+
+/**
+ * How far inside the viewport edge still counts as unreachable. The docked
+ * panel, the Instruments column and the HUD all live at the edges, so a planet
+ * under them is no more clickable than one past the edge entirely.
+ */
+export const TARGET_EDGE_MARGIN = 32;
+
+/**
+ * True when a point is at or behind the camera plane.
+ *
+ * three.js cameras look down -Z in view space, so a non-negative depth is
+ * behind. This has to be tested separately because `graph2ScreenCoords`
+ * projects without a frustum test: a point behind the camera comes back
+ * point-mirrored into view and would otherwise read as a centre-screen hit.
+ */
+export function isBehindCamera(viewSpaceZ: number): boolean {
+  return !(viewSpaceZ < 0);
+}
+
+export function classifyTargetVisibility(params: {
+  /** Depth of the candidate in camera space. */
+  viewSpaceZ: number;
+  /** The candidate projected to screen pixels. */
+  screen: { x: number; y: number };
+  viewport: { width: number; height: number };
+}): TargetVisibility {
+  const { viewSpaceZ, screen, viewport } = params;
+
+  if (isBehindCamera(viewSpaceZ)) return 'behind';
+  if (!Number.isFinite(screen.x) || !Number.isFinite(screen.y)) return 'offscreen';
+
+  const inside =
+    screen.x > TARGET_EDGE_MARGIN &&
+    screen.y > TARGET_EDGE_MARGIN &&
+    screen.x < viewport.width - TARGET_EDGE_MARGIN &&
+    screen.y < viewport.height - TARGET_EDGE_MARGIN;
+
+  return inside ? 'onscreen' : 'offscreen';
+}
+
+/** How many candidates no amount of aiming can reach. */
+export function countUnreachable(visibilities: TargetVisibility[]): number {
+  return visibilities.filter((v) => v !== 'onscreen').length;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,24 +1,57 @@
-import { defineConfig } from 'vite'
+import { defineConfig, type Plugin } from 'vite'
 import react from '@vitejs/plugin-react'
 
+/**
+ * Say out loud which Supabase project the dev server is on.
+ *
+ * A dev server quietly pointed at production looks identical to one pointed at
+ * dev until you write to it, so the project ref is printed on every start.
+ */
+function announceSupabaseProject(): Plugin {
+  return {
+    name: 'osra-announce-supabase-project',
+    apply: 'serve',
+    configResolved(config) {
+      const url = config.env.VITE_SUPABASE_URL as string | undefined
+      const ref = url?.match(/^https:\/\/([^.]+)\./)?.[1] ?? '(missing)'
+      config.logger.info(`  ➜  Supabase:  ${ref}  (from .env.local)\n`)
+    },
+  }
+}
+
 // https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [react()],
-  test: {
-    environment: 'node',
-    include: ['src/**/*.test.ts'],
-  },
-  server: { host: true },
-  build: {
-    rollupOptions: {
-      output: {
-        manualChunks: {
-          'vendor-react': ['react', 'react-dom', 'react-router-dom'],
-          'vendor-three': ['three', '@react-three/fiber', '@react-three/drei', 'react-force-graph-3d', 'three-spritetext'],
-          'vendor-d3': ['d3-drag', 'd3-hierarchy', 'd3-selection', 'd3-shape', 'd3-zoom'],
-          'vendor-motion': ['motion'],
+export default defineConfig(({ command }) => {
+  if (command === 'serve') {
+    // Vite gives real environment variables priority over .env files, so a
+    // VITE_SUPABASE_URL exported in the shell — or inherited from whatever
+    // launched the editor — silently overrides .env.local and points local
+    // testing at the production database. Dev reads .env.local and nothing
+    // else (docs/DEV_VS_PROD_DATABASE.md), so the ambient ones are dropped
+    // before Vite loads them. Builds are left alone: Vercel supplies its env
+    // exactly this way.
+    for (const key of Object.keys(process.env)) {
+      if (key.startsWith('VITE_')) delete process.env[key]
+    }
+  }
+
+  return {
+    plugins: [react(), announceSupabaseProject()],
+    server: { host: true },
+    build: {
+      rollupOptions: {
+        output: {
+          manualChunks: {
+            'vendor-react': ['react', 'react-dom', 'react-router-dom'],
+            'vendor-three': ['three', '@react-three/fiber', '@react-three/drei', 'react-force-graph-3d', 'three-spritetext'],
+            'vendor-d3': ['d3-drag', 'd3-hierarchy', 'd3-selection', 'd3-shape', 'd3-zoom'],
+            'vendor-motion': ['motion'],
+          },
         },
       },
     },
-  },
+    test: {
+      environment: 'node',
+      include: ['src/**/*.test.ts'],
+    },
+  }
 })


### PR DESCRIPTION
Closes LIN-50.

Two-click Connect Mode in the 3D view. A target may be occluded, off-screen, behind the camera, or a few pixels wide, so pure raycasting would leave legitimate targets unlinkable and make bad aim indistinguishable from an invalid target. Three things answer that.

## The camera gate

`onNodeClick` always fired a camera fly-to. `handleGraphNodeClick` now checks `connectModeRef` first, so a target click resolves the pair instead of launching the camera. Manipulation Freeze was dropped after prototyping (ADR 0002), so that gate is the whole of the "camera stays still while aiming" guarantee.

## Candidate affordance

Candidacy is decided up front by asking `buildConnectOptions` (LIN-47) whether *any* of the four Kinship Links could join the pair. Valid targets get a purple rim + halo; everyone else drops to 20% opacity, sphere and label alike. Both fade with the LIN-32 cluster crossfade. A click on a refused target names the reason rather than doing nothing.

## Fallback picker

The docked panel lists targets drawn from the existing `TreeSearchBar` result set, badging (↗) the ones aiming cannot reach and disabling unlinkable rows with their reason. Having typed a name the user means *that person*, so search results are offered verbatim, unlinkable people included; having typed nothing they mean "who can I even link to", so only linkable people are listed, unreachable first.

## Kinship picker & beam

`ConnectPickerCard` mounts **in the docked panel** once a pair is chosen (the panel widens to fit it) — every hit target stays docked, per the LIN-48 prototype verdict. Confirm flips source/target on `parentIsSource === false` and calls `onDirectConnectNodes` -> `handleDirectConnectNodes`, matching 2D.

The tractor beam reuses the existing `isPreviewLink` path rather than a new mechanism. It appears once a pair is chosen rather than under the pointer: each preview link rebuilds `graphData`, and the graph re-runs its warmup ticks when it does.

## Also included

`8f89543` pins the dev server to the dev database. Vite gives real environment variables priority over `.env` files, so a `VITE_SUPABASE_URL` exported in the shell silently overrode `.env.local` and pointed `npm run dev` at production. Ambient `VITE_*` vars are now dropped in serve mode, and the resolved project ref is printed on every dev start. Builds are untouched — Vercel supplies its environment that way on purpose.

## Verification

31 new unit tests across two pure modules (`connectCandidates`, `connectTargeting`); 115 tests, typecheck, and build all pass; no new lint problems against the pre-existing baseline. Manually driven in the 3D view: camera stays put, candidates stand out, off-screen targets are reachable from the picker, pair + docked kinship picker create the link, and Esc/background-click step back out.

## Known gaps

- People behind a collapsed node or hidden cluster are unreachable by aim *and* by the picker — rim-lighting cannot advertise what is not rendered. Deliberate; signed off.
- Desktop-only, per ADR 0002. Mobile keeps the `PersonDetailDrawer` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)