### PR TITLE
feat(tree-3d): Cosmic FX — supernova spawn, black hole dissolve & beam pulse (LIN-51)

### DIFF
--- a/src/components/FamilyTree.tsx
+++ b/src/components/FamilyTree.tsx
@@ -204,7 +204,7 @@ export const FamilyTree: React.FC = () => {
     setActivePreset(userCluster);
   }, []);
 
-  const handleAddRelativeDirect = useCallback((node: FamilyNode, _relation: RelativeDirection) => {
+  const handleAddRelativeDirect = useCallback((node: FamilyNode) => {
     setSelectedNode(node);
   }, []);
 

--- a/src/components/FamilyTree.tsx
+++ b/src/components/FamilyTree.tsx
@@ -24,6 +24,11 @@ import { PersonDetailDrawer } from './PersonDetailDrawer';
 import { isMobile } from '../utils/device';
 import { RelativeDirection } from '../types/graph';
 import { createRelativeSecure, linkExistingRelativeSecure } from '../lib/familyMutations';
+import {
+  BEAM_PULSE_WINDOW_MS,
+  COSMIC_FX_DURATION_MS,
+  type LinkEndpoints,
+} from '../utils/cosmicFx';
 
 export const FamilyTree: React.FC = () => {
   const { user, userProfile, isAdmin, session } = useAuth();
@@ -206,6 +211,20 @@ export const FamilyTree: React.FC = () => {
   // Playful Animation Pipeline State (LIN-45)
   const [newlySpawnedNodeId, setNewlySpawnedNodeId] = useState<string | null>(null);
   const [dissolvingNodeId, setDissolvingNodeId] = useState<string | null>(null);
+  /**
+   * The Kinship Link a Spawn has just created (LIN-51). Its beam pulses in the
+   * 3D view; the 2D view already grows the path itself. Direction-free, because
+   * Connect Mode may flip which end is the parent.
+   */
+  const [pulsingLink, setPulsingLink] = useState<LinkEndpoints | null>(null);
+
+  const pulseLink = useCallback((aId: string, bId: string) => {
+    setPulsingLink({ aId, bId });
+    window.setTimeout(
+      () => setPulsingLink((prev) => (prev?.aId === aId && prev?.bId === bId ? null : prev)),
+      BEAM_PULSE_WINDOW_MS
+    );
+  }, []);
 
   const handleCreateRelativeDirect = useCallback(
     async (params: { firstName: string; relation: RelativeDirection; targetNodeId: string }) => {
@@ -225,13 +244,14 @@ export const FamilyTree: React.FC = () => {
           const newId = res.new_node_id;
           setNewlySpawnedNodeId(newId);
           setTimeout(() => setNewlySpawnedNodeId(null), 3500);
+          pulseLink(params.targetNodeId, newId);
         }
       } catch (e) {
         console.error('[handleCreateRelativeDirect] Error:', e);
         window.alert(e instanceof Error ? e.message : 'Failed to create relative.');
       }
     },
-    [user, session?.access_token, refetch]
+    [user, session?.access_token, refetch, pulseLink]
   );
 
   const handleConnectExistingRelativeDirect = useCallback(
@@ -246,12 +266,13 @@ export const FamilyTree: React.FC = () => {
           sessionToken: session?.access_token,
         });
         await refetch();
+        pulseLink(params.targetNodeId, params.existingNodeId);
       } catch (e) {
         console.error('[handleConnectExistingRelativeDirect] Error:', e);
         window.alert(e instanceof Error ? e.message : 'Failed to connect relative.');
       }
     },
-    [user, session?.access_token, refetch]
+    [user, session?.access_token, refetch, pulseLink]
   );
 
   const handleConfirmDissolveDirect = useCallback(
@@ -259,6 +280,13 @@ export const FamilyTree: React.FC = () => {
       if (!isAdmin || !user) return;
       // Optimistic particle dissolve animation immediately
       setDissolvingNodeId(node.id);
+      // The 2D rendering reports its own completion; the 3D one plays out in
+      // the scene and cannot. Releasing the id on the effect's own clock keeps
+      // a finished Dissolve from shadowing the next Spawn, which loses ties.
+      window.setTimeout(
+        () => setDissolvingNodeId((prev) => (prev === node.id ? null : prev)),
+        COSMIC_FX_DURATION_MS.collapse + 500
+      );
       try {
         await adminDeleteNode({
           session,
@@ -313,12 +341,13 @@ export const FamilyTree: React.FC = () => {
           });
         }
         await refetch();
+        pulseLink(params.sourceNodeId, params.targetNodeId);
       } catch (e) {
         console.error('[handleDirectConnectNodes] Error:', e);
         window.alert(e instanceof Error ? e.message : 'Failed to create kinship link.');
       }
     },
-    [isAdmin, user, session, refetch]
+    [isAdmin, user, session, refetch, pulseLink]
   );
 
   // Visible nodes for search (depends on mode)
@@ -672,6 +701,11 @@ export const FamilyTree: React.FC = () => {
             onCreateRelative={handleCreateRelativeDirect}
             onConnectExistingRelative={handleConnectExistingRelativeDirect}
             onDirectConnectNodes={handleDirectConnectNodes}
+            newlySpawnedNodeId={newlySpawnedNodeId}
+            dissolvingNodeId={dissolvingNodeId}
+            pulsingLink={pulsingLink}
+            canDissolveSelected={isAdmin && canEditSelected}
+            onDissolveNode={handleConfirmDissolveDirect}
           />
         ) : (
           <FamilyTree2D

--- a/src/components/FamilyTree3D.tsx
+++ b/src/components/FamilyTree3D.tsx
@@ -22,8 +22,18 @@ import { getNodeId } from '../utils/getNodeId';
 import { filterGraphDataFor3D } from '../lib/filterGraphData';
 import { useClusterBubbles } from '../hooks/useClusterBubbles';
 import { EXIT_MULT } from '../utils/clusterBubbles';
+import { useCosmicFx } from '../hooks/useCosmicFx';
+import {
+  beamPulseParticleCount,
+  confirmPulseOpacity,
+  BEAM_PULSE_COLOR,
+  BEAM_PULSE_SPEED,
+  BEAM_PULSE_WIDTH,
+  CONFIRM_PULSE_COLOR,
+  type LinkEndpoints,
+} from '../utils/cosmicFx';
 import { TreeSearchBar } from './TreeSearchBar';
-import { Manipulation3DPanel, Connect3DControls } from './Manipulation3DPanel';
+import { Manipulation3DPanel, Connect3DControls, Dissolve3DControls } from './Manipulation3DPanel';
 import {
   Candidacy,
   ConnectPair,
@@ -242,6 +252,18 @@ interface FamilyTree3DProps {
     type: 'parent' | 'marriage' | 'divorce';
     parentRole?: 'mother' | 'father' | null;
   }) => Promise<void> | void;
+  /**
+   * Cosmic FX (LIN-51). These name the node a **Spawn** or **Dissolve** is
+   * happening to, not a separate animation state: the host owns the triggers
+   * and the rollback, exactly as it does for the 2D renderings.
+   */
+  newlySpawnedNodeId?: string | null;
+  dissolvingNodeId?: string | null;
+  /** The Kinship Link just created, whose beam pulses. Direction-free. */
+  pulsingLink?: LinkEndpoints | null;
+  /** Dissolve is admin-only, so the handle is not offered to anyone else. */
+  canDissolveSelected?: boolean;
+  onDissolveNode?: (node: FamilyNode) => Promise<void> | void;
 }
 
 export const FamilyTree3DContent: React.FC<FamilyTree3DProps> = ({
@@ -282,6 +304,11 @@ export const FamilyTree3DContent: React.FC<FamilyTree3DProps> = ({
   onCreateRelative,
   onConnectExistingRelative,
   onDirectConnectNodes,
+  newlySpawnedNodeId = null,
+  dissolvingNodeId = null,
+  pulsingLink = null,
+  canDissolveSelected = false,
+  onDissolveNode,
 }) => {
   const ForceGraph3DAny = ForceGraph3D as unknown as React.ComponentType<any>;
   const { userProfile } = useAuth();
@@ -325,6 +352,15 @@ export const FamilyTree3DContent: React.FC<FamilyTree3DProps> = ({
    */
   const connectModeRef = useRef<string | null>(null);
   connectModeRef.current = connectSource?.id ?? null;
+
+  /**
+   * Delete confirmation (LIN-51): whose aura is pulsing red.
+   *
+   * Held here rather than in the panel because the scene needs it — the pulse
+   * is on the planet, while the ✓ / ✕ hit targets are DOM in the docked panel.
+   * Same split as Connect Mode.
+   */
+  const [confirmingDissolveId, setConfirmingDissolveId] = useState<string | null>(null);
 
   // Internal state for modals
   const [initialCameraPos, setInitialCameraPos] = useState<{ x: number; y: number; z: number } | null>(null);
@@ -484,6 +520,16 @@ export const FamilyTree3DContent: React.FC<FamilyTree3DProps> = ({
     enabled: (filteredGraphData.nodes?.length ?? 0) > 0,
   });
 
+  // Supernova / black hole collapse — the 3D renderings of Spawn and Dissolve
+  // (LIN-51). Refused outright on mobile by the effect budget.
+  useCosmicFx({
+    fgRef,
+    nodes: filteredGraphData.nodes,
+    spawnNodeId: newlySpawnedNodeId,
+    dissolveNodeId: dissolvingNodeId,
+    isMobileDevice,
+  });
+
   // three-forcegraph multiplies linkOpacity as a number (arrows use state.linkOpacity * 3).
   // Per-link visibility must use linkVisibility, not a function passed to linkOpacity.
   const linkVisibility = useCallback((l: any) => {
@@ -494,6 +540,26 @@ export const FamilyTree3DContent: React.FC<FamilyTree3DProps> = ({
   }, [showLinks, showArrows, fullyClustered]);
 
   const nodeVisibility = useCallback(() => !fullyClustered, [fullyClustered]);
+
+  /**
+   * Link growth → beam pulse (LIN-51).
+   *
+   * The graph's own `linkDirectionalParticles` rather than a hand-written
+   * effect: already integrated, free, and nothing to maintain — which is also
+   * why it does not spend any of the hand-written effect budget and is allowed
+   * to keep running (thinned) on mobile.
+   */
+  const linkDirectionalParticles = useCallback(
+    (l: any) => {
+      if (isPreviewLink(l) || !linkVisibility(l)) return 0;
+      return beamPulseParticleCount({
+        endpoints: { aId: getNodeId(l.source), bId: getNodeId(l.target) },
+        pulsing: pulsingLink,
+        isMobileDevice,
+      });
+    },
+    [pulsingLink, isMobileDevice, linkVisibility]
+  );
 
   const linkMaterial = useCallback((l: any) => {
     if (isPreviewLink(l)) {
@@ -586,6 +652,7 @@ export const FamilyTree3DContent: React.FC<FamilyTree3DProps> = ({
 
   const startConnectMode = useCallback(() => {
     if (!selectedNode) return;
+    setConfirmingDissolveId(null);
     setConnectSource(selectedNode);
     setConnectPair(null);
     setRejectedTarget(null);
@@ -692,6 +759,36 @@ export const FamilyTree3DContent: React.FC<FamilyTree3DProps> = ({
       handleConnectConfirm,
     ]
   );
+
+  /**
+   * Delete confirmation, mirroring Connect Mode's split: the panel offers the
+   * hit targets, the scene renders the state.
+   */
+  const handleDissolveConfirm = useCallback(async () => {
+    const node = selectedNode;
+    setConfirmingDissolveId(null);
+    if (!node) return;
+    await Promise.resolve(onDissolveNode?.(node));
+  }, [selectedNode, onDissolveNode]);
+
+  const dissolveControls = useMemo<Dissolve3DControls>(
+    () => ({
+      canDissolve: canDissolveSelected && Boolean(onDissolveNode),
+      isConfirming: Boolean(selectedNode && confirmingDissolveId === selectedNode.id),
+      onStart: () => setConfirmingDissolveId(selectedNode?.id ?? null),
+      onCancel: () => setConfirmingDissolveId(null),
+      onConfirm: handleDissolveConfirm,
+    }),
+    [canDissolveSelected, onDissolveNode, selectedNode, confirmingDissolveId, handleDissolveConfirm]
+  );
+
+  // A confirmation belongs to the node it was raised on; if the selection moves
+  // the docked panel goes with it, so the question no longer has a subject.
+  useEffect(() => {
+    if (confirmingDissolveId && selectedNode?.id !== confirmingDissolveId) {
+      setConfirmingDissolveId(null);
+    }
+  }, [selectedNode, confirmingDissolveId]);
 
   // Reset View functionality
   const resetView = useCallback(() => {
@@ -1126,6 +1223,14 @@ export const FamilyTree3DContent: React.FC<FamilyTree3DProps> = ({
           document.activeElement?.tagName === 'INPUT' || 
           document.activeElement?.tagName === 'TEXTAREA') return;
       
+      // A raised delete confirmation is the innermost state, so Escape answers
+      // that one first rather than deselecting out from under it.
+      if (key === 'escape' && confirmingDissolveId) {
+        e.preventDefault();
+        setConfirmingDissolveId(null);
+        return;
+      }
+
       // Connect Mode is a targeting state: Escape steps back out of it, and the
       // selection shortcuts are held back so the docked panel cannot be pulled
       // out from under a half-made link.
@@ -1203,6 +1308,7 @@ export const FamilyTree3DContent: React.FC<FamilyTree3DProps> = ({
     isBulkInviteOpen,
     connectSource,
     connectPair,
+    confirmingDissolveId,
     exitConnectMode,
     onBackgroundClick,
   ]);
@@ -1286,6 +1392,38 @@ export const FamilyTree3DContent: React.FC<FamilyTree3DProps> = ({
         addConnectShell(geometries.glow, 0.35);
       }
 
+      /**
+       * Delete confirmation (LIN-51): the aura and glow pulse red.
+       *
+       * Not a shake. The camera in this scene never stops moving, so a jittering
+       * mesh reads as a rendering glitch rather than as a question being asked.
+       * The ✓ / ✕ that answer it are DOM, in the docked panel.
+       */
+      if (confirmingDissolveId === node.id) {
+        const startedAt = performance.now();
+        const addConfirmPulse = (
+          geometry: THREE.BufferGeometry,
+          baseOpacity: number,
+          wireframe = false
+        ) => {
+          const material = new THREE.MeshBasicMaterial({
+            color: CONFIRM_PULSE_COLOR,
+            transparent: true,
+            opacity: baseOpacity,
+            wireframe,
+          });
+          const shell = new THREE.Mesh(geometry, material);
+          shell.onBeforeRender = () => {
+            material.opacity =
+              confirmPulseOpacity(performance.now() - startedAt, baseOpacity) *
+              (1 - detailRef.current);
+          };
+          group.add(shell);
+        };
+        addConfirmPulse(geometries.aura, 0.7, true);
+        addConfirmPulse(geometries.glow, 0.25);
+      }
+
       if (showNames) {
         const first = (node.firstName ?? '').trim();
         const cluster = (node.familyCluster ?? '').trim();
@@ -1332,11 +1470,15 @@ export const FamilyTree3DContent: React.FC<FamilyTree3DProps> = ({
     detailRef,
     connectSource,
     connectCandidateIds,
+    confirmingDissolveId,
   ]);
 
   useEffect(() => {
     if (fgRef.current?.refresh) fgRef.current.refresh();
-  }, [nodeTexture, selectedNode?.id, searchHighlightedNodeId, pendingLinkPreview?.anchorId, pendingLinkPreview?.existingId, showArrows, showLinks, connectSource, connectCandidateIds]);
+    // `pulsingLink` is deliberately absent: the beam pulse changes only the link
+    // accessor, whose new identity the graph picks up on its own. Listing it
+    // here would rebuild every planet in the scene to light one edge.
+  }, [nodeTexture, selectedNode?.id, searchHighlightedNodeId, pendingLinkPreview?.anchorId, pendingLinkPreview?.existingId, showArrows, showLinks, connectSource, connectCandidateIds, confirmingDissolveId]);
 
   // Preview pair framing: one shot after layout; deps = endpoint ids only (no simulation churn).
   useEffect(() => {
@@ -1657,6 +1799,10 @@ export const FamilyTree3DContent: React.FC<FamilyTree3DProps> = ({
         linkDirectionalArrowLength={(l: any) =>
           isPreviewLink(l) ? 0 : (showArrows && l.type === 'parent') ? 14 : 0}
         linkDirectionalArrowColor={() => '#60a5fa'}
+        linkDirectionalParticles={linkDirectionalParticles}
+        linkDirectionalParticleSpeed={BEAM_PULSE_SPEED}
+        linkDirectionalParticleWidth={BEAM_PULSE_WIDTH}
+        linkDirectionalParticleColor={() => BEAM_PULSE_COLOR}
         showNavInfo={false}
       />
 
@@ -2049,6 +2195,7 @@ export const FamilyTree3DContent: React.FC<FamilyTree3DProps> = ({
         fgRef={fgRef}
         nodes={filteredGraphData.nodes}
         connect={connectControls}
+        dissolve={dissolveControls}
         searchQuery={searchQuery}
         onSearchQueryChange={onSearchQueryChange}
         searchMatches={searchMatches}

--- a/src/components/Manipulation3DPanel.tsx
+++ b/src/components/Manipulation3DPanel.tsx
@@ -9,6 +9,7 @@ import { Candidacy, ConnectPair, buildTargetOptions } from './cards/connectCandi
 import { CONNECT_ACCENT, relationColor } from './cards/relationStyle';
 import { ConnectTargetingBody } from './ConnectTargetingBody';
 import { countUnreachable } from '../utils/connectTargeting';
+import { CONFIRM_PULSE_COLOR } from '../utils/cosmicFx';
 import { useGhostPreview } from '../hooks/useGhostPreview';
 import { useTargetVisibility } from '../hooks/useTargetVisibility';
 
@@ -27,6 +28,10 @@ import { useTargetVisibility } from '../hooks/useTargetVisibility';
 
 const PANEL_LEFT = 24;
 const PANEL_PADDING = 12;
+
+/** The same red the scene pulses the aura with, so the pill and the planet
+ *  read as one question. */
+const DISSOLVE_ACCENT = CONFIRM_PULSE_COLOR;
 
 const HANDLES: { relation: RelativeDirection; label: string }[] = [
   { relation: 'parent', label: '+ Parent' },
@@ -67,6 +72,23 @@ export interface Connect3DControls {
   ) => Promise<void> | void;
 }
 
+/**
+ * Delete confirmation as the panel sees it (LIN-51).
+ *
+ * Same split as Connect Mode: the state lives in the host because the scene
+ * renders it — the selected planet's aura and glow pulse red — while the ✓ / ✕
+ * that answer the question are DOM here, where they are always hittable.
+ */
+export interface Dissolve3DControls {
+  /** Dissolve is admin-only; the handle is not offered to anyone else. */
+  canDissolve: boolean;
+  /** True while the confirmation is raised on the selected node. */
+  isConfirming: boolean;
+  onStart: () => void;
+  onCancel: () => void;
+  onConfirm: () => Promise<void> | void;
+}
+
 export interface Manipulation3DPanelProps {
   selectedNode: FamilyNode | null;
   /** Action Handles appear only when the active user may edit this person. */
@@ -77,6 +99,7 @@ export interface Manipulation3DPanelProps {
   /** Live simulated nodes — the array handed to the graphData prop. */
   nodes: LiveNodePosition[];
   connect: Connect3DControls;
+  dissolve: Dissolve3DControls;
   /** The existing search query, reused as the fallback target filter. */
   searchQuery: string;
   onSearchQueryChange?: (query: string) => void;
@@ -189,6 +212,7 @@ export const Manipulation3DPanel: React.FC<Manipulation3DPanelProps> = ({
   fgRef,
   nodes,
   connect,
+  dissolve,
   searchQuery,
   onSearchQueryChange,
   searchMatches,
@@ -277,14 +301,22 @@ export const Manipulation3DPanel: React.FC<Manipulation3DPanelProps> = ({
     connect.onStart();
   }, [closeGhostNode, connect]);
 
+  const startDissolve = useCallback(() => {
+    closeGhostNode();
+    dissolve.onStart();
+  }, [closeGhostNode, dissolve]);
+
   if (!selectedNode || !canEdit) return null;
 
   const inConnectMode = Boolean(connect.sourceNode);
+  const isConfirmingDissolve = dissolve.isConfirming && !inConnectMode && !relation;
   const accent = inConnectMode
     ? CONNECT_ACCENT
-    : relation
-      ? relationColor(relation)
-      : '#a78bfa';
+    : isConfirmingDissolve
+      ? DISSOLVE_ACCENT
+      : relation
+        ? relationColor(relation)
+        : '#a78bfa';
 
   // The kinship picker is wider than the Ghost Node card, so the panel takes
   // whichever card it is currently holding.
@@ -335,7 +367,59 @@ export const Manipulation3DPanel: React.FC<Manipulation3DPanelProps> = ({
           {connect.sourceNode?.firstName ?? selectedNode.firstName}
         </div>
 
-        {!relation && !inConnectMode && (
+        {isConfirmingDissolve && (
+          /*
+           * The confirm pill (LIN-51). The question is asked twice over: the
+           * planet's aura pulses red in the scene, and the answer is taken
+           * here, where a hit target cannot be occluded or shrink to a few
+           * pixels at distance.
+           */
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            <div style={{ fontSize: 11, color: 'rgba(255,255,255,0.75)', lineHeight: 1.4 }}>
+              Dissolve <strong>{selectedNode.firstName}</strong>? This cannot be undone.
+            </div>
+            <div style={{ display: 'flex', gap: 8 }}>
+              <button
+                type="button"
+                onClick={() => dissolve.onConfirm()}
+                aria-label={`Confirm dissolving ${selectedNode.firstName}`}
+                style={{
+                  flex: 1,
+                  background: DISSOLVE_ACCENT,
+                  border: `1.5px solid ${DISSOLVE_ACCENT}`,
+                  borderRadius: 999,
+                  color: '#0f172a',
+                  cursor: 'pointer',
+                  fontSize: 13,
+                  fontWeight: 800,
+                  padding: '6px 10px',
+                }}
+              >
+                ✓
+              </button>
+              <button
+                type="button"
+                onClick={dissolve.onCancel}
+                aria-label="Keep this person"
+                style={{
+                  flex: 1,
+                  background: 'rgba(15, 23, 42, 0.92)',
+                  border: '1.5px solid rgba(255,255,255,0.3)',
+                  borderRadius: 999,
+                  color: 'rgba(255,255,255,0.85)',
+                  cursor: 'pointer',
+                  fontSize: 13,
+                  fontWeight: 800,
+                  padding: '6px 10px',
+                }}
+              >
+                ✕
+              </button>
+            </div>
+          </div>
+        )}
+
+        {!relation && !inConnectMode && !isConfirmingDissolve && (
           <>
             {HANDLES.map(({ relation: rel, label }) => (
               <button
@@ -374,6 +458,25 @@ export const Manipulation3DPanel: React.FC<Manipulation3DPanelProps> = ({
             >
               🔗 Connect
             </button>
+            {dissolve.canDissolve && (
+              <button
+                type="button"
+                onClick={startDissolve}
+                style={{
+                  background: 'rgba(15, 23, 42, 0.92)',
+                  border: `1.5px solid ${DISSOLVE_ACCENT}`,
+                  borderRadius: 999,
+                  color: DISSOLVE_ACCENT,
+                  cursor: 'pointer',
+                  fontSize: 11,
+                  fontWeight: 700,
+                  padding: '6px 10px',
+                  textAlign: 'left',
+                }}
+              >
+                ✕ Dissolve
+              </button>
+            )}
           </>
         )}
 

--- a/src/hooks/useCosmicFx.ts
+++ b/src/hooks/useCosmicFx.ts
@@ -1,0 +1,223 @@
+import { useEffect, useRef } from 'react';
+import * as THREE from 'three';
+import { ForceGraphRef, LiveNodePosition } from '../types/forceGraph';
+import {
+  CosmicEffectKind,
+  COSMIC_FX_COLORS,
+  COSMIC_FX_DURATION_MS,
+  COSMIC_FX_PARTICLES,
+  COSMIC_FX_PARTICLE_SIZE,
+  collapseCoreScale,
+  cosmicParticleOffset,
+  cosmicParticleOpacity,
+  resolveCosmicFxBudget,
+  seedCosmicParticles,
+  supernovaShellScale,
+} from '../utils/cosmicFx';
+
+/**
+ * How long to wait for the anchor to acquire simulated coordinates.
+ *
+ * A Spawn fires as soon as the mutation returns, which is often before the
+ * refetched node has been through a simulation tick and has an x/y/z at all.
+ * Giving up immediately would drop most supernovae; waiting forever would leak
+ * an effect for a node that never arrives.
+ */
+const ANCHOR_WAIT_MS = 2000;
+
+/**
+ * Supernova and black-hole collapse in the scene (LIN-51, ADR 0002).
+ *
+ * These are the 3D renderings of the **Spawn** and **Dissolve** lifecycles, not
+ * new lifecycles: the host still owns the triggers and the optimistic-update
+ * and rollback semantics, and hands this hook nothing but the node the
+ * lifecycle is happening to. Nothing here is raycast or clickable.
+ *
+ * The budget is what makes this droppable. It refuses hand-written effects
+ * outright on mobile, caps the particle count, and holds the scene to one
+ * concurrent effect — on a scene that already carries a starfield, nebulae,
+ * planet textures, auras and glow spheres before any of this is layered on.
+ */
+export function useCosmicFx(params: {
+  fgRef: ForceGraphRef;
+  /** Live simulated nodes — the array handed to the graphData prop. */
+  nodes: LiveNodePosition[];
+  /** Node that has just been created; renders a supernova at it. */
+  spawnNodeId: string | null;
+  /** Node being removed; renders a black hole collapse at it. */
+  dissolveNodeId: string | null;
+  /** Hand-written effects are off on mobile, per the performance budget. */
+  isMobileDevice: boolean;
+}): void {
+  const { fgRef, nodes, spawnNodeId, dissolveNodeId, isMobileDevice } = params;
+
+  // Read through a ref so a new array identity does not restart a playing
+  // effect — the useGhostPreview / useClusterBubbles precedent.
+  const nodesRef = useRef(nodes);
+  nodesRef.current = nodes;
+
+  /** Effects currently in the scene, so the concurrency cap is enforced rather
+   *  than merely assumed from the shape of the code. */
+  const activeRef = useRef(0);
+
+  // Dissolve wins a tie: it is the one the user has just confirmed, and the
+  // node it belongs to is about to stop existing.
+  const kind: CosmicEffectKind | null = dissolveNodeId
+    ? 'collapse'
+    : spawnNodeId
+      ? 'supernova'
+      : null;
+  const nodeId = dissolveNodeId ?? spawnNodeId;
+
+  useEffect(() => {
+    if (!kind || !nodeId) return;
+
+    const budget = resolveCosmicFxBudget({
+      requested: COSMIC_FX_PARTICLES[kind],
+      isMobileDevice,
+      activeEffects: activeRef.current,
+    });
+    if (!budget.allowed) return;
+
+    const fg = fgRef.current;
+    const scene = fg?.scene?.();
+    if (!scene) return;
+
+    const seeds = seedCosmicParticles(budget.particleCount);
+    const positions = new Float32Array(seeds.length * 3);
+    const colors = new Float32Array(seeds.length * 3);
+    const palette = COSMIC_FX_COLORS[kind].map((hex) => new THREE.Color(hex));
+    seeds.forEach((_, i) => {
+      const colour = palette[i % palette.length];
+      colors[i * 3] = colour.r;
+      colors[i * 3 + 1] = colour.g;
+      colors[i * 3 + 2] = colour.b;
+    });
+
+    const geometry = new THREE.BufferGeometry();
+    geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+    geometry.setAttribute('color', new THREE.BufferAttribute(colors, 3));
+
+    const material = new THREE.PointsMaterial({
+      size: COSMIC_FX_PARTICLE_SIZE,
+      vertexColors: true,
+      transparent: true,
+      // Additive over a black sky is what gives these their heat. Depth writes
+      // are off so the cloud cannot punch holes in the planets behind it.
+      blending: THREE.AdditiveBlending,
+      depthWrite: false,
+    });
+
+    const points = new THREE.Points(geometry, material);
+    // The cloud is positioned by its group; culling it against a bounding
+    // sphere that never updates would blink it out at the edges of the view.
+    points.frustumCulled = false;
+
+    // One companion mesh each: the shock front of a supernova, the dark core a
+    // collapse falls into. Without them the two read as the same cloud running
+    // in opposite directions.
+    const coreGeometry = new THREE.SphereGeometry(10, 12, 12);
+    const coreMaterial =
+      kind === 'supernova'
+        ? new THREE.MeshBasicMaterial({
+            color: 0xfff7d6,
+            transparent: true,
+            wireframe: true,
+            depthWrite: false,
+            blending: THREE.AdditiveBlending,
+          })
+        : new THREE.MeshBasicMaterial({ color: 0x05010a, transparent: true, opacity: 1 });
+    const core = new THREE.Mesh(coreGeometry, coreMaterial);
+    core.scale.setScalar(0);
+
+    const group = new THREE.Group();
+    group.name = `cosmic-fx-${kind}`;
+    // Held back until the anchor is known, so nothing flashes at the origin.
+    group.visible = false;
+    group.add(points, core);
+    scene.add(group);
+    activeRef.current += 1;
+
+    const duration = COSMIC_FX_DURATION_MS[kind];
+    const positionAttribute = geometry.getAttribute('position') as THREE.BufferAttribute;
+    let frameId = 0;
+    let waitingSince: number | null = null;
+    let startedAt: number | null = null;
+    let disposed = false;
+
+    const dispose = () => {
+      if (disposed) return;
+      disposed = true;
+      activeRef.current -= 1;
+      cancelAnimationFrame(frameId);
+      // Detach via the live parent rather than the captured scene, so a
+      // re-created graph scene cannot strand these objects.
+      group.parent?.remove(group);
+      geometry.dispose();
+      material.dispose();
+      coreGeometry.dispose();
+      coreMaterial.dispose();
+    };
+
+    const anchorOf = (id: string) => {
+      const live = nodesRef.current.find((n) => n.id === id);
+      return live &&
+        typeof live.x === 'number' &&
+        typeof live.y === 'number' &&
+        typeof live.z === 'number'
+        ? live
+        : null;
+    };
+
+    const tick = (now: number) => {
+      if (disposed) return;
+      frameId = requestAnimationFrame(tick);
+      if (waitingSince === null) waitingSince = now;
+
+      // Ride the simulation while the node is there. A Dissolve outlives its
+      // node — the delete lands and the refetch removes it mid-flight — so once
+      // started, a missing anchor means hold the last known position.
+      const anchor = anchorOf(nodeId);
+      if (anchor) {
+        group.position.set(anchor.x as number, anchor.y as number, anchor.z as number);
+      } else if (startedAt === null) {
+        if (now - waitingSince > ANCHOR_WAIT_MS) dispose();
+        return;
+      }
+
+      if (startedAt === null) {
+        startedAt = now;
+        group.visible = true;
+      }
+
+      const t = (now - startedAt) / duration;
+      if (t >= 1) {
+        dispose();
+        return;
+      }
+
+      for (let i = 0; i < seeds.length; i++) {
+        const offset = cosmicParticleOffset(kind, seeds[i], t);
+        positions[i * 3] = offset.x;
+        positions[i * 3 + 1] = offset.y;
+        positions[i * 3 + 2] = offset.z;
+      }
+      positionAttribute.needsUpdate = true;
+
+      const opacity = cosmicParticleOpacity(kind, t);
+      material.opacity = opacity;
+
+      if (kind === 'supernova') {
+        core.scale.setScalar(supernovaShellScale(t));
+        coreMaterial.opacity = opacity;
+      } else {
+        core.scale.setScalar(collapseCoreScale(t));
+      }
+    };
+
+    frameId = requestAnimationFrame(tick);
+    return dispose;
+    // `nodes` is deliberately absent: it is read through a ref, and depending on
+    // it would restart the effect on every simulation tick.
+  }, [kind, nodeId, isMobileDevice, fgRef]);
+}

--- a/src/hooks/useFamilyData.ts
+++ b/src/hooks/useFamilyData.ts
@@ -19,9 +19,11 @@ export function useFamilyData() {
     }
   }, [session, user]);
 
-  const fetchFamilyData = async (): Promise<void> => {
+  const fetchFamilyData = async (isBackground = false): Promise<void> => {
     try {
-      setIsLoading(true);
+      if (!isBackground) {
+        setIsLoading(true);
+      }
       setError(null);
 
       const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
@@ -162,7 +164,7 @@ export function useFamilyData() {
     }
   };
 
-  const refetch = (): Promise<void> => fetchFamilyData();
+  const refetch = (): Promise<void> => fetchFamilyData(true);
 
   return { graphData, isLoading, error, refetch };
 }

--- a/src/utils/cosmicFx.test.ts
+++ b/src/utils/cosmicFx.test.ts
@@ -1,0 +1,335 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveCosmicFxBudget,
+  seedCosmicParticles,
+  cosmicParticleOffset,
+  cosmicParticleOpacity,
+  collapseCoreScale,
+  beamPulseParticleCount,
+  isPulsingLink,
+  confirmPulseOpacity,
+  COSMIC_FX_MAX_PARTICLES,
+  COSMIC_FX_MAX_CONCURRENT,
+  COSMIC_FX_PARTICLES,
+  COSMIC_FX_DURATION_MS,
+  COSMIC_REACH_MIN,
+  COSMIC_REACH_MAX,
+  supernovaShellScale,
+  SUPERNOVA_SHELL_MAX_SCALE,
+  BEAM_PULSE_PARTICLES,
+  BEAM_PULSE_PARTICLES_MOBILE,
+  CONFIRM_PULSE_MIN_OPACITY,
+  CONFIRM_PULSE_MAX_OPACITY,
+  CONFIRM_PULSE_PERIOD_MS,
+  type CosmicEffectKind,
+  type CosmicParticleSeed,
+} from './cosmicFx';
+
+const KINDS: CosmicEffectKind[] = ['supernova', 'collapse'];
+
+/** A deterministic stand-in for Math.random, cycling a fixed sequence. */
+function sequenceRandom(values: number[]): () => number {
+  let i = 0;
+  return () => values[i++ % values.length];
+}
+
+function magnitude(v: { x: number; y: number; z: number }): number {
+  return Math.sqrt(v.x * v.x + v.y * v.y + v.z * v.z);
+}
+
+const seed: CosmicParticleSeed = { dx: 0, dy: 0, dz: 1, reach: 40, swirl: Math.PI };
+
+describe('resolveCosmicFxBudget', () => {
+  it('allows a normal effect on desktop with nothing else playing', () => {
+    expect(resolveCosmicFxBudget({ requested: 160, isMobileDevice: false, activeEffects: 0 })).toEqual({
+      allowed: true,
+      particleCount: 160,
+    });
+  });
+
+  it('refuses every hand-written effect on mobile', () => {
+    expect(resolveCosmicFxBudget({ requested: 160, isMobileDevice: true, activeEffects: 0 })).toEqual({
+      allowed: false,
+      particleCount: 0,
+    });
+  });
+
+  it('refuses a second concurrent effect', () => {
+    expect(
+      resolveCosmicFxBudget({
+        requested: 160,
+        isMobileDevice: false,
+        activeEffects: COSMIC_FX_MAX_CONCURRENT,
+      })
+    ).toEqual({ allowed: false, particleCount: 0 });
+  });
+
+  it('caps the particle count rather than refusing an over-large request', () => {
+    const budget = resolveCosmicFxBudget({
+      requested: COSMIC_FX_MAX_PARTICLES * 10,
+      isMobileDevice: false,
+      activeEffects: 0,
+    });
+    expect(budget.allowed).toBe(true);
+    expect(budget.particleCount).toBe(COSMIC_FX_MAX_PARTICLES);
+  });
+
+  it('refuses an empty request instead of adding an invisible effect to the scene', () => {
+    expect(resolveCosmicFxBudget({ requested: 0, isMobileDevice: false, activeEffects: 0 })).toEqual({
+      allowed: false,
+      particleCount: 0,
+    });
+  });
+
+  it('holds every shipped effect inside the budget without needing the cap', () => {
+    expect(COSMIC_FX_MAX_CONCURRENT).toBe(1);
+    for (const kind of KINDS) {
+      expect(COSMIC_FX_PARTICLES[kind]).toBeGreaterThan(0);
+      expect(COSMIC_FX_PARTICLES[kind]).toBeLessThanOrEqual(COSMIC_FX_MAX_PARTICLES);
+    }
+  });
+});
+
+describe('seedCosmicParticles', () => {
+  it('produces exactly the requested number of particles', () => {
+    expect(seedCosmicParticles(0, Math.random)).toEqual([]);
+    expect(seedCosmicParticles(37, Math.random)).toHaveLength(37);
+  });
+
+  it('gives every particle a unit direction, so reach alone sets the distance', () => {
+    for (const s of seedCosmicParticles(64, Math.random)) {
+      expect(magnitude({ x: s.dx, y: s.dy, z: s.dz })).toBeCloseTo(1, 5);
+    }
+  });
+
+  it('keeps reach inside the tuned band', () => {
+    for (const s of seedCosmicParticles(64, Math.random)) {
+      expect(s.reach).toBeGreaterThanOrEqual(COSMIC_REACH_MIN);
+      expect(s.reach).toBeLessThanOrEqual(COSMIC_REACH_MAX);
+    }
+  });
+
+  it('scatters over the whole sphere rather than a single plane', () => {
+    const particles = seedCosmicParticles(200, Math.random);
+    expect(particles.some((s) => s.dy > 0.5)).toBe(true);
+    expect(particles.some((s) => s.dy < -0.5)).toBe(true);
+    expect(particles.some((s) => s.dx > 0.5)).toBe(true);
+    expect(particles.some((s) => s.dx < -0.5)).toBe(true);
+  });
+
+  it('is a pure function of the supplied randomness', () => {
+    const values = [0.1, 0.37, 0.62, 0.88, 0.24, 0.5];
+    expect(seedCosmicParticles(8, sequenceRandom(values))).toEqual(
+      seedCosmicParticles(8, sequenceRandom(values))
+    );
+  });
+});
+
+describe('cosmicParticleOffset', () => {
+  it('starts a supernova at the node centre and ends it at full reach', () => {
+    expect(magnitude(cosmicParticleOffset('supernova', seed, 0))).toBeCloseTo(0, 5);
+    expect(magnitude(cosmicParticleOffset('supernova', seed, 1))).toBeCloseTo(seed.reach, 5);
+  });
+
+  it('bursts a supernova outwards fastest at the start', () => {
+    const early = magnitude(cosmicParticleOffset('supernova', seed, 0.25));
+    const late = magnitude(cosmicParticleOffset('supernova', seed, 0.75));
+    // Past halfway the particles are coasting, so most of the distance is
+    // already behind them — that head start is what reads as an explosion.
+    expect(early).toBeGreaterThan(seed.reach * 0.5);
+    expect(late).toBeGreaterThan(early);
+  });
+
+  it('starts a collapse at full reach and swallows it at the centre', () => {
+    expect(magnitude(cosmicParticleOffset('collapse', seed, 0))).toBeCloseTo(seed.reach, 5);
+    expect(magnitude(cosmicParticleOffset('collapse', seed, 1))).toBeCloseTo(0, 5);
+  });
+
+  it('draws a collapse in slowly, then snaps it shut', () => {
+    const half = magnitude(cosmicParticleOffset('collapse', seed, 0.5));
+    // Halfway through, most of the distance is still to fall — the acceleration
+    // is what separates a black hole from a fade-out.
+    expect(half).toBeGreaterThan(seed.reach * 0.5);
+  });
+
+  it('moves monotonically towards its destination for both kinds', () => {
+    for (const kind of KINDS) {
+      const radii = Array.from({ length: 21 }, (_, i) =>
+        magnitude(cosmicParticleOffset(kind, seed, i / 20))
+      );
+      for (let i = 1; i < radii.length; i++) {
+        if (kind === 'supernova') expect(radii[i]).toBeGreaterThanOrEqual(radii[i - 1]);
+        else expect(radii[i]).toBeLessThanOrEqual(radii[i - 1]);
+      }
+    }
+  });
+
+  it('spirals a collapse without changing how far it has fallen', () => {
+    const spun: CosmicParticleSeed = { dx: 1, dy: 0, dz: 0, reach: 40, swirl: Math.PI };
+    const straight: CosmicParticleSeed = { ...spun, swirl: 0 };
+    const t = 0.6;
+    expect(magnitude(cosmicParticleOffset('collapse', spun, t))).toBeCloseTo(
+      magnitude(cosmicParticleOffset('collapse', straight, t)),
+      5
+    );
+    expect(cosmicParticleOffset('collapse', spun, t).z).not.toBeCloseTo(
+      cosmicParticleOffset('collapse', straight, t).z,
+      5
+    );
+  });
+
+  it('leaves a supernova travelling straight out from its anchor', () => {
+    const offset = cosmicParticleOffset('supernova', { ...seed, swirl: Math.PI }, 0.5);
+    expect(offset.x).toBeCloseTo(0, 5);
+    expect(offset.y).toBeCloseTo(0, 5);
+    expect(offset.z).toBeGreaterThan(0);
+  });
+});
+
+describe('cosmicParticleOpacity', () => {
+  it('starts every effect fully lit and ends it invisible', () => {
+    for (const kind of KINDS) {
+      expect(cosmicParticleOpacity(kind, 0)).toBeCloseTo(1, 5);
+      expect(cosmicParticleOpacity(kind, 1)).toBeCloseTo(0, 5);
+    }
+  });
+
+  it('never brightens partway through', () => {
+    for (const kind of KINDS) {
+      let prev = Infinity;
+      for (let i = 0; i <= 20; i++) {
+        const value = cosmicParticleOpacity(kind, i / 20);
+        expect(value).toBeLessThanOrEqual(prev + 1e-9);
+        expect(value).toBeGreaterThanOrEqual(0);
+        prev = value;
+      }
+    }
+  });
+
+  it('keeps a collapse burning until it is swallowed, unlike a fading supernova', () => {
+    // The particles converge on a point; dimming them on the way in would read
+    // as a fade-out rather than as something being pulled under.
+    expect(cosmicParticleOpacity('collapse', 0.7)).toBeCloseTo(1, 5);
+    expect(cosmicParticleOpacity('supernova', 0.7)).toBeLessThan(0.5);
+  });
+
+  it('clamps outside the effect window so a late frame cannot revive it', () => {
+    for (const kind of KINDS) {
+      expect(cosmicParticleOpacity(kind, 1.5)).toBe(0);
+      expect(cosmicParticleOpacity(kind, -0.5)).toBeCloseTo(1, 5);
+    }
+  });
+
+  it('gives each effect a duration short enough to stay out of the way', () => {
+    for (const kind of KINDS) {
+      expect(COSMIC_FX_DURATION_MS[kind]).toBeGreaterThan(0);
+      expect(COSMIC_FX_DURATION_MS[kind]).toBeLessThanOrEqual(2000);
+    }
+  });
+});
+
+describe('collapseCoreScale', () => {
+  it('is nothing at both ends, so the core never outlives the effect', () => {
+    expect(collapseCoreScale(0)).toBeCloseTo(0, 5);
+    expect(collapseCoreScale(1)).toBeCloseTo(0, 5);
+  });
+
+  it('peaks while the particles are still falling in', () => {
+    expect(collapseCoreScale(0.5)).toBeGreaterThan(collapseCoreScale(0.1));
+    expect(collapseCoreScale(0.5)).toBeGreaterThan(collapseCoreScale(0.9));
+  });
+
+  it('never goes negative, which would invert the mesh', () => {
+    for (let i = -2; i <= 22; i++) expect(collapseCoreScale(i / 20)).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe('supernovaShellScale', () => {
+  it('starts inside the node and expands past it', () => {
+    expect(supernovaShellScale(0)).toBeCloseTo(0, 5);
+    expect(supernovaShellScale(1)).toBeCloseTo(SUPERNOVA_SHELL_MAX_SCALE, 5);
+    expect(SUPERNOVA_SHELL_MAX_SCALE).toBeGreaterThan(1);
+  });
+
+  it('never contracts, so the shock front only ever moves outwards', () => {
+    let prev = -Infinity;
+    for (let i = 0; i <= 20; i++) {
+      const value = supernovaShellScale(i / 20);
+      expect(value).toBeGreaterThanOrEqual(prev);
+      prev = value;
+    }
+  });
+
+  it('leads the particles out, arriving before they do', () => {
+    expect(supernovaShellScale(0.25) / SUPERNOVA_SHELL_MAX_SCALE).toBeGreaterThan(0.5);
+  });
+});
+
+describe('isPulsingLink', () => {
+  const pulsing = { aId: 'x', bId: 'y' };
+
+  it('matches the pulsing pair in either direction', () => {
+    expect(isPulsingLink({ aId: 'x', bId: 'y' }, pulsing)).toBe(true);
+    expect(isPulsingLink({ aId: 'y', bId: 'x' }, pulsing)).toBe(true);
+  });
+
+  it('leaves every other link alone', () => {
+    expect(isPulsingLink({ aId: 'x', bId: 'z' }, pulsing)).toBe(false);
+    expect(isPulsingLink({ aId: 'x', bId: 'y' }, null)).toBe(false);
+  });
+});
+
+describe('beamPulseParticleCount', () => {
+  const pulsing = { aId: 'x', bId: 'y' };
+
+  it('runs beads down the link that was just created', () => {
+    expect(
+      beamPulseParticleCount({ endpoints: { aId: 'x', bId: 'y' }, pulsing, isMobileDevice: false })
+    ).toBe(BEAM_PULSE_PARTICLES);
+  });
+
+  it('leaves every other link unlit, so the whole tree does not shimmer', () => {
+    expect(
+      beamPulseParticleCount({ endpoints: { aId: 'p', bId: 'q' }, pulsing, isMobileDevice: false })
+    ).toBe(0);
+    expect(
+      beamPulseParticleCount({ endpoints: { aId: 'x', bId: 'y' }, pulsing: null, isMobileDevice: false })
+    ).toBe(0);
+  });
+
+  it('thins the beam on mobile but does not cut it, since the graph draws it for free', () => {
+    expect(
+      beamPulseParticleCount({ endpoints: { aId: 'x', bId: 'y' }, pulsing, isMobileDevice: true })
+    ).toBe(BEAM_PULSE_PARTICLES_MOBILE);
+    expect(BEAM_PULSE_PARTICLES_MOBILE).toBeGreaterThan(0);
+    expect(BEAM_PULSE_PARTICLES_MOBILE).toBeLessThan(BEAM_PULSE_PARTICLES);
+  });
+});
+
+describe('confirmPulseOpacity', () => {
+  it('stays inside the tuned band, so the aura never blinks out or goes solid', () => {
+    for (let ms = 0; ms <= CONFIRM_PULSE_PERIOD_MS * 2; ms += 37) {
+      const value = confirmPulseOpacity(ms, 1);
+      expect(value).toBeGreaterThanOrEqual(CONFIRM_PULSE_MIN_OPACITY - 1e-9);
+      expect(value).toBeLessThanOrEqual(CONFIRM_PULSE_MAX_OPACITY + 1e-9);
+    }
+  });
+
+  it('repeats every period, so the pulse reads as a steady heartbeat', () => {
+    for (const ms of [0, 120, 640]) {
+      expect(confirmPulseOpacity(ms, 1)).toBeCloseTo(
+        confirmPulseOpacity(ms + CONFIRM_PULSE_PERIOD_MS, 1),
+        5
+      );
+    }
+  });
+
+  it('scales with the base opacity it is given', () => {
+    expect(confirmPulseOpacity(400, 0.5)).toBeCloseTo(confirmPulseOpacity(400, 1) * 0.5, 5);
+  });
+
+  it('is expressed in milliseconds, not frames, so it beats at the same rate on any display', () => {
+    const quarter = confirmPulseOpacity(CONFIRM_PULSE_PERIOD_MS / 4, 1);
+    expect(quarter).toBeCloseTo(CONFIRM_PULSE_MAX_OPACITY, 5);
+  });
+});

--- a/src/utils/cosmicFx.ts
+++ b/src/utils/cosmicFx.ts
@@ -1,0 +1,286 @@
+/**
+ * Cosmic FX: the 3D renderings of the Spawn and Dissolve lifecycles (LIN-51,
+ * ADR 0002).
+ *
+ * Supernova and black-hole collapse are *renderings*, not lifecycles — same
+ * triggers, same optimistic-update and rollback semantics as the 2D
+ * `SpawnBurst` / `ParticleDissolve`. Those are SVG `<g>` particle systems with
+ * nothing portable in them, so this is the shared maths for a rewrite rather
+ * than a port.
+ *
+ * Deliberately free of three.js types. Hosts own the meshes; everything here is
+ * numbers, which is what makes the performance budget below testable rather
+ * than tuned by eye.
+ */
+
+export type CosmicEffectKind = 'supernova' | 'collapse';
+
+/**
+ * The performance budget, stated as code because the scene is already loaded:
+ * a starfield, nebulae, planet textures, auras and glow spheres are all drawn
+ * before any of this. ≤1 concurrent hand-written effect, ≤200 particles, and
+ * nothing hand-written at all on mobile — alongside the geometry and material
+ * reductions `FamilyTree3D` already makes there.
+ */
+export const COSMIC_FX_MAX_PARTICLES = 200;
+export const COSMIC_FX_MAX_CONCURRENT = 1;
+
+export const COSMIC_FX_PARTICLES: Record<CosmicEffectKind, number> = {
+  supernova: 160,
+  collapse: 140,
+};
+
+export const COSMIC_FX_DURATION_MS: Record<CosmicEffectKind, number> = {
+  supernova: 1400,
+  collapse: 1100,
+};
+
+/** How far particles travel, in world units. A node sphere has radius 10. */
+export const COSMIC_REACH_MIN = 26;
+export const COSMIC_REACH_MAX = 62;
+
+/** Radians a collapse particle spins about the world Y axis over its life. */
+export const COLLAPSE_MAX_SWIRL = Math.PI * 1.6;
+
+/**
+ * Palettes carried over from the 2D `SpawnBurst` / `ParticleDissolve`, so the
+ * same lifecycle reads as the same event in either view.
+ */
+export const COSMIC_FX_COLORS: Record<CosmicEffectKind, string[]> = {
+  supernova: ['#fef08a', '#ffffff', '#38bdf8', '#818cf8', '#c084fc', '#4ade80'],
+  collapse: ['#f87171', '#fb923c', '#fbbf24', '#c084fc', '#60a5fa', '#ffffff'],
+};
+
+/** Point size in world units, before distance attenuation. */
+export const COSMIC_FX_PARTICLE_SIZE = 3.4;
+
+export interface CosmicParticleSeed {
+  /** Unit direction from the node centre; reach alone sets the distance. */
+  dx: number;
+  dy: number;
+  dz: number;
+  /** Distance from the centre at full expansion, in world units. */
+  reach: number;
+  /** Radians of spin about the world Y axis; ignored by the supernova. */
+  swirl: number;
+}
+
+export interface CosmicFxBudget {
+  allowed: boolean;
+  particleCount: number;
+}
+
+/**
+ * Whether an effect may play at all, and with how many particles.
+ *
+ * A refusal is a normal outcome, not a failure: polish was split into its own
+ * milestone precisely so it can be dropped without holding the functional work
+ * hostage, and this is where that drop happens.
+ */
+export function resolveCosmicFxBudget(params: {
+  requested: number;
+  isMobileDevice: boolean;
+  /** Hand-written effects already playing in the scene. */
+  activeEffects: number;
+}): CosmicFxBudget {
+  const { requested, isMobileDevice, activeEffects } = params;
+  const refused: CosmicFxBudget = { allowed: false, particleCount: 0 };
+
+  if (requested <= 0) return refused;
+  if (isMobileDevice) return refused;
+  if (activeEffects >= COSMIC_FX_MAX_CONCURRENT) return refused;
+
+  return { allowed: true, particleCount: Math.min(requested, COSMIC_FX_MAX_PARTICLES) };
+}
+
+/**
+ * Particle seeds scattered over a sphere.
+ *
+ * Directions come from the inverse-CDF construction (uniform in cos φ) rather
+ * than from three uniform components: the naive version bunches particles at
+ * the poles, which reads as a cross rather than a blast.
+ */
+export function seedCosmicParticles(
+  count: number,
+  random: () => number = Math.random
+): CosmicParticleSeed[] {
+  const seeds: CosmicParticleSeed[] = [];
+  for (let i = 0; i < count; i++) {
+    const cosPhi = random() * 2 - 1;
+    const sinPhi = Math.sqrt(Math.max(0, 1 - cosPhi * cosPhi));
+    const theta = random() * Math.PI * 2;
+    seeds.push({
+      dx: sinPhi * Math.cos(theta),
+      dy: cosPhi,
+      dz: sinPhi * Math.sin(theta),
+      reach: COSMIC_REACH_MIN + random() * (COSMIC_REACH_MAX - COSMIC_REACH_MIN),
+      swirl: random() * COLLAPSE_MAX_SWIRL,
+    });
+  }
+  return seeds;
+}
+
+function clamp01(t: number): number {
+  return t < 0 ? 0 : t > 1 ? 1 : t;
+}
+
+/** Distance from the node centre at normalised time `t`. */
+function cosmicRadius(kind: CosmicEffectKind, seed: CosmicParticleSeed, t: number): number {
+  const clamped = clamp01(t);
+  if (kind === 'supernova') {
+    // Ease-out cubic: nearly all the distance is covered in the first half, so
+    // the burst throws rather than drifts.
+    const inv = 1 - clamped;
+    return seed.reach * (1 - inv * inv * inv);
+  }
+  // Ease-in cubic, inverted: barely moves at first, then falls in all at once.
+  return seed.reach * (1 - clamped * clamped * clamped);
+}
+
+/**
+ * Where a particle sits relative to the node centre, in world units.
+ *
+ * The collapse spins about the world Y axis on the way in. A straight radial
+ * implosion reads as a vacuum cleaner; the spiral is what makes it a black
+ * hole. The supernova ignores `swirl` — an exploding star throws debris out
+ * along straight lines.
+ */
+export function cosmicParticleOffset(
+  kind: CosmicEffectKind,
+  seed: CosmicParticleSeed,
+  t: number
+): { x: number; y: number; z: number } {
+  const radius = cosmicRadius(kind, seed, t);
+
+  if (kind === 'supernova') {
+    return { x: seed.dx * radius, y: seed.dy * radius, z: seed.dz * radius };
+  }
+
+  // Accelerating spin, so the swirl tightens as the particle is pulled under.
+  const clamped = clamp01(t);
+  const angle = seed.swirl * clamped * clamped;
+  const cos = Math.cos(angle);
+  const sin = Math.sin(angle);
+  return {
+    x: (seed.dx * cos + seed.dz * sin) * radius,
+    y: seed.dy * radius,
+    z: (-seed.dx * sin + seed.dz * cos) * radius,
+  };
+}
+
+/**
+ * Brightness at normalised time `t`.
+ *
+ * The two curves are deliberately different. A supernova is spending itself as
+ * it expands, so it dims the whole way out. A collapse converges on a point —
+ * dimming it on the way in would read as a fade-out rather than as something
+ * being swallowed — so it holds full brightness and is extinguished at the end.
+ */
+export const COLLAPSE_EXTINGUISH_FROM = 0.85;
+
+export function cosmicParticleOpacity(kind: CosmicEffectKind, t: number): number {
+  const clamped = clamp01(t);
+  if (kind === 'supernova') {
+    const inv = 1 - clamped;
+    return inv * Math.sqrt(inv);
+  }
+  if (clamped < COLLAPSE_EXTINGUISH_FROM) return 1;
+  return (1 - clamped) / (1 - COLLAPSE_EXTINGUISH_FROM);
+}
+
+/**
+ * The supernova's shock shell, in node-sphere radii.
+ *
+ * It rides the same ease-out as the particles but arrives ahead of them, so the
+ * burst reads as a detonation with a front rather than as a cloud drifting
+ * apart. Its opacity is the particles' own, so the two die together.
+ */
+export const SUPERNOVA_SHELL_MAX_SCALE = 4.5;
+
+export function supernovaShellScale(t: number): number {
+  const inv = 1 - clamp01(t);
+  return SUPERNOVA_SHELL_MAX_SCALE * (1 - inv * inv * inv);
+}
+
+/**
+ * Scale of the dark core a collapse falls into: nothing, swelling as the
+ * particles arrive, gone with them. It is the one thing that says "black hole"
+ * rather than "particles moving inwards", and costs a single small mesh.
+ */
+export function collapseCoreScale(t: number): number {
+  return Math.sin(Math.PI * clamp01(t));
+}
+
+/**
+ * A Kinship Link identified by its two ends, direction-free.
+ *
+ * The graph mutates `link.source` / `link.target` from ids into node objects
+ * once the simulation runs, and Connect Mode may flip which end is the parent,
+ * so matching on ordered endpoints would miss half the time.
+ */
+export interface LinkEndpoints {
+  aId: string;
+  bId: string;
+}
+
+/**
+ * Link growth is rendered with the graph's built-in `linkDirectionalParticles`
+ * rather than a hand-written effect: it is already integrated, costs nothing to
+ * maintain, and does not spend any of the budget above.
+ */
+/** How long a newly grown link keeps its beads, matching the Spawn window. */
+export const BEAM_PULSE_WINDOW_MS = 3500;
+
+export const BEAM_PULSE_PARTICLES = 6;
+export const BEAM_PULSE_PARTICLES_MOBILE = 3;
+export const BEAM_PULSE_SPEED = 0.012;
+export const BEAM_PULSE_WIDTH = 2.5;
+export const BEAM_PULSE_COLOR = '#a5f3fc';
+
+export function isPulsingLink(
+  endpoints: LinkEndpoints,
+  pulsing: LinkEndpoints | null
+): boolean {
+  if (!pulsing) return false;
+  return (
+    (endpoints.aId === pulsing.aId && endpoints.bId === pulsing.bId) ||
+    (endpoints.aId === pulsing.bId && endpoints.bId === pulsing.aId)
+  );
+}
+
+export function beamPulseParticleCount(params: {
+  endpoints: LinkEndpoints;
+  pulsing: LinkEndpoints | null;
+  isMobileDevice: boolean;
+}): number {
+  if (!isPulsingLink(params.endpoints, params.pulsing)) return 0;
+  return params.isMobileDevice ? BEAM_PULSE_PARTICLES_MOBILE : BEAM_PULSE_PARTICLES;
+}
+
+/**
+ * Delete confirmation: the node's aura and glow pulse red.
+ *
+ * Not a shake. A mesh jittering under a live camera — which never stops moving
+ * in this scene — reads as a rendering glitch rather than as a question being
+ * asked. The geometry is already there (`geometries.aura`, `geometries.glow`),
+ * so this only recolours and modulates it, and is paired with a DOM confirm
+ * pill in the overlay that carries the actual ✓ / ✕ hit targets.
+ *
+ * Expressed per millisecond: a per-frame counter would beat at whatever rate
+ * the display happens to run at.
+ */
+export const CONFIRM_PULSE_PERIOD_MS = 900;
+export const CONFIRM_PULSE_MIN_OPACITY = 0.25;
+export const CONFIRM_PULSE_MAX_OPACITY = 1;
+/** Shared by the in-scene aura and the DOM confirm pill, so they read as one
+ *  question rather than two unrelated red things. */
+export const CONFIRM_PULSE_COLOR = '#ef4444';
+
+export function confirmPulseOpacity(elapsedMs: number, baseOpacity: number): number {
+  const phase = (elapsedMs / CONFIRM_PULSE_PERIOD_MS) * Math.PI * 2;
+  const unit = (Math.sin(phase) + 1) / 2;
+  return (
+    baseOpacity *
+    (CONFIRM_PULSE_MIN_OPACITY + (CONFIRM_PULSE_MAX_OPACITY - CONFIRM_PULSE_MIN_OPACITY) * unit)
+  );
+}


### PR DESCRIPTION
### Summary
- Renders 3D Cosmic FX for Spawn (supernova burst + expanding shock shell) and Dissolve (black hole collapse with inward spiral into dark core).
- Adds beam pulse animation on newly connected Kinship Links.
- Adds delete confirmation with red pulsing aura on the 3D node and docked panel confirm buttons.
- Prevents full-screen reload unmount during graph background refetch so WebGL animations play seamlessly.
- Enforces mobile & concurrency performance budgets.