### PR TITLE
docs: restore survey evidence and decision rationale dropped from ad3ec13

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -19,12 +19,12 @@ A typed genealogical edge connecting two Persons (`parent`, `marriage`, or `divo
 _Avoid_: Edge, Connection, Wire, Branch
 
 **Tree Record**:
-The single source of truth and deep write module (`src/lib/treeRecord.ts`) that owns every mutation to Persons and Kinship Links in the tree archive.
-_Avoid_: Mutation service, REST helpers, Direct fetch
+The persisted set of Persons and Kinship Links — the authoritative family tree, as distinct from the Tree Nodes drawn on a canvas.
+_Avoid_: Family tree (already names three view components), Graph, Store, Database
 
 **Relative Direction**:
-A relative relation framed from the perspective of an anchor Person (`parent`, `child`, `spouse`, `sibling`). Converted at module edges into an absolute Kinship Link.
-_Avoid_: Edge type (when referring to directional intent)
+The direction an Action Handle points — Parent, Child, Spouse or Sibling — expressed relative to an anchor Person. It is not a Kinship Link type: Parent and Child both resolve to a `parent` link with the endpoints reversed, Spouse resolves to `marriage`, Sibling resolves to a `parent` link from the anchor's own parents, and `divorce` has no Relative Direction at all.
+_Avoid_: Relation type, Link type, Relationship
 
 ### Direct Interaction
 

--- a/docs/adr/0003-tree-record-write-seam.md
+++ b/docs/adr/0003-tree-record-write-seam.md
@@ -49,8 +49,31 @@ This fragmentation produced:
    - Retained `canEdit` for UI render gating.
    - Replaced all 13 call sites and deleted `familyMutations.ts` and `adminSupabaseRest.ts`.
 
+## The division of authorization labour
+
+The module checks **admin-ness**. It does not check **1-degree kinship**, and it deliberately does not receive the Kinship Links needed to compute it. This looks wrong — `canEdit` is sitting right there in `permissions.ts` — so the reasoning is recorded here.
+
+The split follows what each side can actually enforce:
+
+- The three `*_secure` RPCs are `SECURITY DEFINER` and self-authorizing — they verify `auth.uid() = creator_id` and then `is_admin() OR is_within_1_degree()`. The database does 1-degree well; duplicating it client-side would be decoration.
+- The four raw REST paths are **not** admin-gated by the database. `POST /nodes` is satisfied by `nodes_insert_by_bound_users` for any bound user; `POST /links` and `PATCH /links` treat `is_admin()` as one disjunct of three; `PATCH /nodes` allows any 1-degree update. Only `DELETE /links` genuinely requires admin. For those four paths a client-side boolean was the *only* gate, distributed across React props.
+
+So the module checks the thing the database doesn't, and leaves the database the thing it already enforces.
+
+**The module's check is a UI affordance, not a security boundary.** It runs in the browser and is forgeable. It exists so the gate is singular and visible rather than scattered, not because it protects anything. The real fix is DB-side and is tracked in LIN-59.
+
+## Considered and rejected
+
+- **Passing the full `{ userId, isAdmin, userNodeId, links }` so the module could run `canEdit` properly.** Rejected: `canEdit` needs the entire Kinship Link array, which would drag the Tree Record's read model into the interface of a module that exists to narrow it. Depth is a property of the interface; this would have widened it.
+- **Two adapters, admin and non-admin, chosen by the caller.** Rejected: caller-chosen routing is what produced the Connect Mode defect. The caller should not need to know which transport its write takes.
+- **Leaving the raw REST writes outside the module and absorbing only the RPC-backed paths.** Rejected: that leaves precisely the four ungated paths outside the seam.
+- **An in-memory fake as the test double.** Rejected: the drift that actually occurred was in *request bodies* — `familyMutations.ts` and `AddRelativeModal.tsx` built the same RPC body with different trims and different error text. A fake at the module interface cannot see that; an injected `fetch` can.
+
 ## Consequences
 
 - All tree writes now share uniform error handling, telemetry potential, and identity routing.
 - The defect where non-admins could create faulty parent links via divorce is closed at both the UI picker level and module level.
 - Server-side RLS gaps for raw REST endpoints remain documented under LIN-59.
+- **Recording a divorce is admin-only.** This was previously an accident — the non-admin RPC takes a Relative Direction, and `divorce` has none — but it is now a deliberate product rule (LIN-61). Connect Mode disables the option for non-admins rather than letting the module refuse after the fact, and the module refuses as a backstop. Expect this to be re-proposed: `marriage` is unrestricted for the same users, so "why can they record the marriage but not the divorce?" is the obvious question. The answer is that a divorce is a claim about two living relatives that the tree should not let an arbitrary 1-degree relative assert unilaterally. Reversing it means a migration, not a client change.
+- That rule is **not yet enforced by the database**. `links_insert_1degree_or_admin` permits a non-admin to create a `divorce` link by going straight at `POST /rest/v1/links`, since admin is only one disjunct of three. Until LIN-59 lands, the restriction lives entirely in the client — exactly like the admin gate described above.
+- The interface is the test surface. Six operations behind one injected `fetch`.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -6,7 +6,10 @@ Issues and specs for this repo live in the **LinearFB** workspace on Linear, und
 
 - **Workspace**: LinearFB (`https://linear.app/linearfb`)
 - **Team**: LinearFB (ID: `e54a1a9e-9b96-447a-8f6a-b8f1dd6b40d2`)
+- **Project**: Osra (ID: `4896eba0-6f46-411f-ab1d-4bdd0353c6cd`)
 - **Issue prefix**: `LIN-`
+
+**Every issue created from this repo belongs to the Osra project.** Always pass `project: "Osra"` to `save_issue` — it is not applied by default, and issues created without it land loose in the team.
 
 ## Existing labels
 
@@ -31,7 +34,7 @@ Issues and specs for this repo live in the **LinearFB** workspace on Linear, und
 
 ## Conventions
 
-- **Create an issue**: Use `save_issue` with `title`, `team: "LinearFB"`, and `description` (Markdown). Add labels, priority, and state as needed.
+- **Create an issue**: Use `save_issue` with `title`, `team: "LinearFB"`, `project: "Osra"`, and `description` (Markdown). Add labels, priority, and state as needed.
 - **Read an issue**: Use `get_issue` with the identifier (e.g. `LIN-123`). Pass `includeRelations: true` for blocking/related edges.
 - **List issues**: Use `list_issues` with filters (`team`, `status`, `label`, `assignee`, `query`).
 - **Update an issue**: Use `save_issue` with `id: "LIN-123"` plus the fields to change.
@@ -41,7 +44,7 @@ Issues and specs for this repo live in the **LinearFB** workspace on Linear, und
 
 ## When a skill says "publish to the issue tracker"
 
-Create a Linear issue via `save_issue` with `team: "LinearFB"`.
+Create a Linear issue via `save_issue` with `team: "LinearFB"` and `project: "Osra"`.
 
 ## When a skill says "fetch the relevant ticket"
 

--- a/docs/plans/2026-08-17-architecture-review.md
+++ b/docs/plans/2026-08-17-architecture-review.md
@@ -1,48 +1,262 @@
-# Architecture Review & Survey: Tree Record Write Seam (2026-08-17)
+# Architecture review — 2026-08-17
 
-## Overview
+Survey output from `/improve-codebase-architecture`. Six **deepening opportunities**, ranked. Each candidate is an *idea*, not a ticket: pick one, take it into `/grill-with-docs`, and let that produce the spec.
 
-A systematic survey was conducted across all write operations to `nodes` and `links` to evaluate interface depth, failure modes, security boundaries, and vocabulary consistency across the Osra codebase.
+Vocabulary is `/codebase-design` (module, interface, implementation, depth, seam, adapter, leverage, locality) for architecture, and [`CONTEXT.md`](../../CONTEXT.md) (Tree Record, Person, Tree Node, Kinship Link, Relative Direction, Action Handle, Ghost Node, Connect Mode, Ghost Preview, Spawn, Dissolve) for the domain.
 
-## Survey Findings
+**Tracker**: LIN-53 … LIN-58 (see each candidate). **LIN-53 is done** — see [Outcome: candidate 01](#outcome-candidate-01--shipped) at the end of this file. Candidates 02–06 remain open.
 
-Prior to unification under `src/lib/treeRecord.ts`, the codebase had eight fragmented write paths across 13 call sites:
+## Scope
 
-1. `createRelativeSecure` (`src/lib/familyMutations.ts`): RPC `create_relative_secure`
-2. `linkExistingRelativeSecure` (`src/lib/familyMutations.ts`): RPC `link_existing_relative_secure`
-3. `adminInsertNode` (`src/lib/adminSupabaseRest.ts`): REST `POST /nodes`
-4. `adminInsertLink` (`src/lib/adminSupabaseRest.ts`): REST `POST /links`
-5. `adminPatchLink` (`src/lib/adminSupabaseRest.ts`): REST `PATCH /links`
-6. `adminDeleteLink` (`src/lib/adminSupabaseRest.ts`): REST `DELETE /links`
-7. `adminDeleteNode` (`src/lib/adminSupabaseRest.ts`): RPC `admin_delete_node_secure`
-8. Direct inline `fetch(PATCH /nodes)` (`src/components/modals/EditNodeModal.tsx`)
+Scoped to the hot spots in the last 40 commits — `FamilyTree3D.tsx` (11 touches), `FamilyTree.tsx` (8), `FamilyTree2D.tsx` (7) — plus the mutation path underneath all three. `CONTEXT.md`, ADR-0001 and ADR-0002 were read first.
 
-### Key Vulnerabilities and Defects Identified
+## Baseline numbers
 
-1. **Connect Mode Fallthrough Defect (`FamilyTree.tsx:333`)**:
-   When a non-admin picked `divorce` in Connect Mode, the mapping logic lacked a divorce case and fell through to `'child'`, quietly creating a parent link in the database.
-   *Resolution*: Refuse divorce for non-admins with `TreeRecordError('refused')`, and disable the option up front in `ConnectPickerCard`.
+| | |
+|---|---|
+| Database write paths | **13**, across 3 unrelated modules |
+| Props at the view seam | **61** (3D) / **42** (2D) |
+| Tests touching any write path | **0** of 163 cases |
+| Genuinely deep modules found | **3** (the 3D hooks — leave them alone) |
 
-2. **Server-Side Authorization Discrepancies (Spinoff LIN-59)**:
-   The three `*_secure` RPCs are `SECURITY DEFINER` with database-level checks, but the raw REST endpoints (`/nodes`, `/links`) had incomplete RLS policies where client-side `isAdmin` was the only gate.
-   *Tracking*: Spinoff issue filed as LIN-59.
+## Ordering
 
-3. **Invite Token Exposure (Spinoff LIN-60)**:
-   Invite tokens were enumerable using the public anon key.
-   *Tracking*: Spinoff issue filed as LIN-60.
+```
+01 ──┬── 02
+     ├── 03 ──┬── 06
+     │        │
+     └────────┘
+04, 05  (independent, grab anytime)
+```
 
-4. **Product Question on Divorce (Spinoff LIN-61)**:
-   Should non-admins be permitted to record divorces in a future migration?
-   *Tracking*: Spinoff issue filed as LIN-61.
+- **02, 03** are blocked on **01**: both need a substitutable write module to test against.
+- **06** is blocked on **01** and **03**.
+- **04, 05** have no blockers.
 
-## Unified Architecture
+> **Citations go stale.** Every `file:line` below is a pointer to re-verify, not a fact — candidate 01 will move most of them. If you pick up a later candidate long after 01 lands, re-run `/improve-codebase-architecture` rather than trusting this file. What this file preserves that a re-run cannot is *which candidates were considered*; what an ADR preserves is *which were rejected and why*.
 
-Consolidated all eight write paths into `src/lib/treeRecord.ts` with six coherent operations:
-- `addPerson`
-- `addLink`
-- `editPerson`
-- `editLink`
-- `removePerson`
-- `removeLink`
+---
 
-Full architectural decisions are documented in [`docs/adr/0003-tree-record-write-seam.md`](../adr/0003-tree-record-write-seam.md).
+## 01 — Give the Tree Record a write module
+
+**Strong** · ports & adapters · `LIN-53` · **DONE** — shipped as `src/lib/treeRecord.ts`, see the Outcome section below
+
+**Files** — `src/lib/familyMutations.ts`, `src/lib/adminSupabaseRest.ts`, `src/lib/permissions.ts`, `src/components/FamilyTree.tsx:229–351`, `src/components/modals/{AddRelative,EditNode,BulkInvite}Modal.tsx`, `src/pages/InvitePage.tsx:151`
+
+**Problem** — The same write is implemented three times, so the fork between admin and non-admin, and the authorization check, sit at call sites instead of behind an interface.
+
+**Solution** — One module owning every write to `nodes`, `links` and `node_invites`. It decides admin routing internally and takes the caller's identity, not a caller-supplied `isAdmin` boolean.
+
+### Evidence
+
+Zero writes go through the Supabase JS client — `src/lib/supabase.ts` is imported only by `AuthContext.tsx` for auth. Every data operation is a hand-rolled `fetch` against `/rest/v1/`.
+
+| # | Site | Target | Via a module? |
+|---|---|---|---|
+| 1 | `familyMutations.ts:31` | `rpc/create_relative_secure` | is the module |
+| 2 | `familyMutations.ts:64` | `rpc/link_existing_relative_secure` | is the module |
+| 3 | `adminSupabaseRest.ts:42` | `rpc/admin_delete_node_secure` | separate module |
+| 4–7 | `adminSupabaseRest.ts:80,109,135,155` | `nodes`, `links` ×3 | separate module |
+| 8 | `AddRelativeModal.tsx:111` | `rpc/link_existing_relative_secure` | **bypasses — duplicate of #2** |
+| 9 | `AddRelativeModal.tsx:143` | `rpc/create_relative_secure` | **bypasses — duplicate of #1** |
+| 10 | `EditNodeModal.tsx:99` | `PATCH /nodes` | **bypasses — sole writer of node updates** |
+| 11–12 | `BulkInviteModal.tsx:193,218` | `node_invites` | **bypasses** |
+| 13 | `InvitePage.tsx:151` | `rpc/claim_invite_secure` | **bypasses** |
+
+`nodes` is written from 5 places, `links` from 7. The `supabaseUrl`/`supabaseKey`/`authToken` triple is re-derived from `import.meta.env` in **10 files**.
+
+**A live defect the missing seam is already producing** — `FamilyTree.tsx:333–334`:
+
+```ts
+const relType: RelativeDirection =
+  params.type === 'parent' ? 'parent' : params.type === 'marriage' ? 'spouse' : 'child';
+```
+
+The admin/non-admin fork lives in a React callback. For a non-admin, `'divorce'` falls through to `'child'` — Connect Mode's divorce option silently writes a parent link.
+
+**Duplicated request bodies** — `familyMutations.ts:38–44` and `AddRelativeModal.tsx:150–156` build the identical RPC body, differing only in error text and where the 200-char trim happens. `AddRelativeModal.tsx:18` declares its own `RelationshipType` including `'sibling'` and posts it straight through, which `RelativeDirection` (`graph.ts:30`) forbids.
+
+**Permissions belong at this same seam**
+
+- `permissions.ts:16 canEdit` is never called on a write path — all 8 call sites gate a render.
+- `requireAdmin` (`adminSupabaseRest.ts:3`) checks a boolean the caller passed in. It is a UI assertion, not a check.
+- `canCreateLink` (`permissions.ts:228`) has **zero call sites**. Connect Mode does structural validation (`validateProposedLink`) and no authorization check at all.
+- `isAdmin` is derived four ways: `AuthContext.tsx:170`, then recomputed inline at `FamilyTree.tsx:85`, `:643`, and `PersonDetailDrawer.tsx:51`.
+- The admin bypass is defeated at the call site: `permissions.ts:23` says `if (isAdmin) return true`, but `FamilyTree.tsx:84` guards the whole call on `userProfile?.node_id`. An admin with a null `node_id` gets 2D Action Handles (`FamilyTree2D.tsx:500`, unguarded) but not the 3D panel. The two renderings disagree because each re-derives the answer.
+
+**Wins** — locality: routing bug fixable once · leverage: 13 call sites, 1 interface · the interface becomes the test surface · `canEdit` gates writes, not renders · deletes 10 env re-derivations.
+
+---
+
+## 02 — Put the direct-manipulation state machine behind one interface
+
+**Strong** · in-process · `LIN-54` · blocked by `LIN-53`
+
+**Files** — `src/components/FamilyTree.tsx` (762), `FamilyTree2D.tsx` (1042), `FamilyTree3D.tsx` (2211), `NodeCard.tsx:66`
+
+**Problem** — Selection, Ghost Node, Connect Mode and Dissolve confirmation are written twice with different types, and the props list is the union of both implementations' internals — so no one can change one rendering without reading the other.
+
+**Solution** — One module owns the state machine and exposes what each rendering must draw. The renderings keep their own chrome, camera and geometry.
+
+> **Bounded by ADR-0002.** The ADR deliberately diverges the 2D and 3D *interaction models* — directional Action Handles vs a docked panel — and that divergence must survive. The seam goes **behind** the renderings, not through them: what unifies is the state machine (which Tree Node is the connect source, is a Ghost Node open, is a Dissolve awaiting confirmation), not how it is drawn. This does not reopen ADR-0002.
+
+### Evidence — five leaks across the current seam
+
+- **Escape precedence duplicated 3×** — `FamilyTree2D.tsx:294` (keydown), `:433` (background click), and `ConnectPickerCard.tsx:54` (a third window listener whose `stopPropagation` cannot reach its sibling). All encode the same four-level fallthrough.
+- **Two connect modes** — the inline one at `FamilyTree2D.tsx:179–181` and an admin one at `FamilyTree.tsx:56–59` that the 2D rendering knows nothing about.
+- **Selection split three ways** — parent holds it (`FamilyTree.tsx:44`), the child intercepts clicks first (`FamilyTree2D.tsx:453`), the parent intercepts again for admin connect (`:134`).
+- **Delete confirmation lives in a leaf card** — `NodeCard.tsx:66` holds `isConfirmingDissolve` and auto-cancels it on a hover heuristic (`:69–73`).
+- **`onAddRelative` drops its argument** — declared with `relation` (`FamilyTree2D.tsx:86`), the parent's handler ignores it (`FamilyTree.tsx:207`) because the real value never left the child.
+
+Concepts held in both with different types: `connectPair` (`FamilyTree2D.tsx:181` as `{source,target}: Node2D` vs `FamilyTree3D.tsx:340` as `ConnectPair` of `FamilyNode`), `activePreset`, `showControls`.
+
+Dead across the seam: `onStartConnect` (`FamilyTree2D.tsx:87`, never passed), `onStartDissolve` (`NodeCard.tsx:21`, unreachable), `(FamilyTree2D as any).focusNode` (`:427`, read by nobody). `React.memo` is applied at `FamilyTree2D.tsx:1042`, `NodeCard.tsx:525` and `OrthogonalLinks.tsx:58` but every consumer imports the unmemoized named export — so every `NodeCard` re-renders on every pan.
+
+**Wins** — interface: 61 props → a handful · locality: one Escape precedence · leverage: 2 renderings, 1 machine · state machine testable without a DOM.
+
+---
+
+## 03 — Make Spawn and Dissolve one lifecycle with one clock
+
+**Strong** · in-process · `LIN-55` · blocked by `LIN-53`
+
+**Files** — `src/components/FamilyTree.tsx:212–226, 278–308`, `NodeCard.tsx:66–103`, `FamilyTree2D.tsx:703–717`, `ParticleDissolve.tsx`, `SpawnBurst.tsx`, `hooks/useCosmicFx.ts`
+
+**Problem** — `CONTEXT.md` and ADR-0002 both say Spawn and Dissolve are one lifecycle rendered two ways. In the code the lifecycle is four fragments on three disagreeing clocks, and its documented rollback is a flag.
+
+**Solution** — One module per lifecycle owning phase, clock and rollback, with the two renderings as adapters behind it — the split `CONTEXT.md` already names.
+
+### Evidence
+
+Three clocks for one Dissolve:
+
+| Clock | Duration | Where |
+|---|---|---|
+| `cardDissolve` CSS | 450 ms | `NodeCard.tsx:101` |
+| particle sim | ~1000 ms | `ParticleDissolve.tsx:56–72` |
+| release timer | 1600 ms | `FamilyTree.tsx:286` (`COSMIC_FX_DURATION_MS.collapse + 500`) |
+
+- **The completion signal is unreachable.** `ParticleDissolve` is rendered by iterating the *post-refetch* `nodes` (`FamilyTree2D.tsx:703–717`). Once the refetch lands the node is gone, so it unmounts before its particles expire and `onComplete` never fires. `FamilyTree.tsx:750` is dead; the 1600 ms timer is the real releaser — while the comment at `:283–285` asserts the opposite.
+- **Rollback races its own timer.** `FamilyTree.tsx:303` sets `dissolvingNodeId` to null on error, but `:286` already scheduled the same thing. Either way it only cancels an animation flag; no graph state is restored.
+- **`SpawnBurst.onComplete` is never passed** (`FamilyTree2D.tsx:690`). The 3500 ms timer at `FamilyTree.tsx:246` is the only releaser.
+- **Two unrelated delete paths reach one endpoint** — the in-tree Dissolve, and `PersonDetailDrawer` → `handleAdminDeleteSelectedNode` (`FamilyTree.tsx:156`) with a native `window.confirm` and no animation at all.
+- **The 2D delete affordance is not permission-gated.** `FamilyTree2D.tsx:677` gates the handle on `canEdit` (1-degree relatives) but `FamilyTree.tsx:280` bails on `!isAdmin`. A non-admin 1-degree relative sees the handle, sees the shake, clicks ✓, and nothing happens — no error, no feedback. 3D passes `canDissolveSelected={isAdmin && canEditSelected}` (`:707`); 2D gets no equivalent.
+
+**Leave the 3D hooks alone.** `useCosmicFx` (223 L), `useGhostPreview` (182 L) and `useClusterBubbles` (419 L) are already deep — 823 lines of rAF loops, raycasting and Three.js disposal behind three signatures, two returning `void`. They own their own `scene.add`/`dispose` lifecycles correctly. The friction is above them.
+
+**Wins** — locality: one clock, one owner · dead `onComplete` path removed · phase machine testable, no DOM · domain language reaches the code.
+
+---
+
+## 04 — Make the live graph a module, not a shape you defend against
+
+**Worth exploring** · in-process · `LIN-56` · no blockers
+
+**Files** — `src/types/graph.ts:3–46`, `src/utils/getNodeId.ts`, `src/lib/permissions.ts:52`, `src/utils/familyContext.ts:24`, `FamilyTree3D.tsx`, `BulkInviteModal.tsx`
+
+**Problem** — `FamilyLink.source` is typed `string`, but d3-force rewrites it to a node object in place. Every reader defends itself, and three of the copies drop to `any`.
+
+**Solution** — Type the endpoints as unknown-until-resolved and make the accessor the only way to read them.
+
+### Evidence — one canonical helper, four re-implementations
+
+| Implementation | Note |
+|---|---|
+| `utils/getNodeId.ts:4` | canonical, null-safe; used by `filterGraphData`, `adminGraphValidation`, `AdminManageLinksModal` |
+| `permissions.ts:52 getSafeId` | byte-equivalent copy, `any`-typed |
+| `familyContext.ts:24 getId` | third copy, one line |
+| `FamilyTree3D.tsx:861,947,948,973,974,1599` | inlined with `as any` |
+| `BulkInviteModal.tsx:73–114` | inlined **ten times** in one file |
+
+Four parallel shapes for one thing: DB row (`database.ts:42`), domain `FamilyNode`/`FamilyLink` (`graph.ts:3`), `Node2D`/`Link2D` whose endpoints are *objects* (`graph.ts:33`), and the force-graph runtime shape that `LiveNodePosition` (`forceGraph.ts:26`) describes but is never used as.
+
+Related: `parentRole` is `null` in the DB, converted to `undefined` at `useFamilyData.ts:118`, and papered over at `adminGraphValidation.ts:43` with `(a.parentRole ?? null) === (b.parentRole ?? null)`. `FamilyLink.id` is optional (`graph.ts:17`) because `filterGraphData.ts:71` pushes synthetic parent links without one — which then appear in Manage Links as permanently un-editable rows.
+
+**Wins** — deletes ~20 inline re-reads · 3 `any` escapes removed from the security-relevant module · locality: one place d3 leaks.
+
+---
+
+## 05 — One module for duplicate-Person matching
+
+**Worth exploring** · in-process · `LIN-57` · no blockers
+
+**Files** — `src/components/cards/ghostNodeCandidates.ts:16`, `modals/AddRelativeModal.tsx:63`, `modals/EditNodeModal.tsx:47`
+
+**Problem** — "Is this Person already in the tree?" is a domain question with three inconsistent answers, and the strictest one guards the path ADR-0001 demoted.
+
+**Solution** — One module answering the question and returning the resolution the caller must make (`none` / `candidates` / `must-confirm`), so the guard travels with the answer.
+
+### Evidence
+
+| Implementation | Min chars | Matches on | Cap | Sorted | Blocks submit |
+|---|---|---|---|---|---|
+| `ghostNodeCandidates.ts:16` *(inline, 2D+3D)* | 2 | full haystack | 4 | no | **no** |
+| `AddRelativeModal.tsx:63` | 3 | full haystack | none | yes | **yes** |
+| `EditNodeModal.tsx:47` | 3 | `firstName` only | none | no | n/a |
+
+`AddRelativeModal.tsx:175–178` blocks submit until the user resolves a duplicate. `GhostNodeCard.tsx:61–74` has no equivalent guard — so the primary path ADR-0001 chose creates duplicate Persons with no confirmation, and the fallback path is the one that's safe.
+
+Separately, the candidate pool is wrong on the primary path: `FamilyTree2D.tsx:724` passes the *unfiltered* graph, so picking a match in a hidden cluster writes a Kinship Link the user never sees appear.
+
+**Wins** — locality: one threshold to tune · guard reaches the primary path · the existing 8 tests in `ghostNodeCandidates.test.ts` come to cover all callers · smallest candidate here.
+
+---
+
+## 06 — A graph store that can be updated, not only refetched
+
+**Speculative** · local-substitutable · `LIN-58` · blocked by `LIN-53`, `LIN-55`
+
+**Files** — `src/hooks/useFamilyData.ts:22–167`, `FamilyTree.tsx` (11 refetch sites), `hooks/useFamilyChat.ts:16`
+
+**Problem** — Every write is `await write; await refetch()` — a full re-download of every Person and Kinship Link plus the claimed-ids RPC. There is no optimistic update anywhere in the codebase.
+
+**Solution** — A store whose interface is add / update / remove plus reconcile, so a write touches one Person instead of replacing the graph.
+
+### Evidence
+
+- `refetch()` fires from 11 sites: `FamilyTree.tsx:171,241,268,296,343,474,583,591,607,620,632`.
+- The Spawn animation waits on three network round-trips before it can start (`FamilyTree.tsx:241` then `:245`).
+- **Pinned positions are destroyed.** `FamilyTree3D.tsx:988–999` and `:1095–1111` write `fx/fy/fz` onto the node objects held in React state, in place. `useFamilyData.ts:130` shallow-clones *links* to survive exactly this problem — nodes get no such treatment, so `:158` replaces them and every pin is silently discarded.
+- **The 2D viewport recentres mid-animation.** `FamilyTree2D.tsx:237–261` depends on `bounds`, rebuilt on every refetch. The comment claims "only re-center on initial load"; the dep array `[bounds, nodes.length === 0]` does not implement that.
+- **Two copies of the graph.** `useFamilyChat.ts:16` calls `useFamilyData()` a second time, and `FamilyChat` mounts unconditionally at `FamilyTree.tsx:757`. The chat copy has no `refetch` wiring and goes stale on the first write.
+
+**Why speculative** — largest change here, depends on 01 and 03 landing first, and its payoff is partly performance, which nobody has complained about.
+
+**Wins** — real rollback, not a flag · pinned positions survive writes · one graph in memory, not two.
+
+---
+
+## Not candidates — deliberately
+
+- **The three 3D hooks are deep. Leave them.** See 03.
+- **Test harness gap, noted not proposed.** `vite.config.ts:52–55` sets `environment: 'node'` and `include: ['src/**/*.test.ts']` — no DOM, and a `.test.tsx` would not even be collected. That's why 163 test cases render zero components. Candidates 01–03 are all chosen so their payoff lands *inside* this constraint rather than requiring it be lifted.
+- **`layoutEngine.ts`** — 643 lines of pure, DOM-free functions with zero tests. Not an architecture problem; just missing tests. Worth a ticket, not a deepening.
+
+---
+
+## Outcome: candidate 01 — shipped
+
+LIN-53 landed as `src/lib/treeRecord.ts` (+ `treeRecord.test.ts`). `familyMutations.ts` and `adminSupabaseRest.ts` are deleted. Recorded here so the survey above stays readable as a *before* picture rather than silently going stale.
+
+**The eight write paths that were consolidated:**
+
+1. `createRelativeSecure` (`familyMutations.ts`) — RPC `create_relative_secure`
+2. `linkExistingRelativeSecure` (`familyMutations.ts`) — RPC `link_existing_relative_secure`
+3. `adminInsertNode` (`adminSupabaseRest.ts`) — REST `POST /nodes`
+4. `adminInsertLink` (`adminSupabaseRest.ts`) — REST `POST /links`
+5. `adminPatchLink` (`adminSupabaseRest.ts`) — REST `PATCH /links`
+6. `adminDeleteLink` (`adminSupabaseRest.ts`) — REST `DELETE /links`
+7. `adminDeleteNode` (`adminSupabaseRest.ts`) — RPC `admin_delete_node_secure`
+8. Inline `fetch(PATCH /nodes)` (`EditNodeModal.tsx`)
+
+**Into six operations** — `addPerson`, `addLink`, `editPerson`, `editLink`, `removePerson`, `removeLink` — constructed via `createTreeRecord(identity, config)`, with `relativeToKinshipLink()` as the single conversion point from Relative Direction to Kinship Link, and `TreeRecordError` carrying `kind: 'refused' | 'not-authorized' | 'network' | 'conflict' | 'unknown'`.
+
+**The Connect Mode defect is closed.** A non-admin picking `divorce` fell through to `'child'` at `FamilyTree.tsx:333` and quietly wrote a parent link. It is now refused with `TreeRecordError('refused')` and disabled up front in `ConnectPickerCard`. Full decisions in [`docs/adr/0003-tree-record-write-seam.md`](../adr/0003-tree-record-write-seam.md).
+
+**Spin-offs filed from this work:**
+
+- **LIN-59** — four write paths are not admin-gated server-side; `isAdmin` is a client boolean with no DB backstop
+- **LIN-60** — invite tokens enumerable with the publishable anon key; `claim_invite_secure` never checks expiry
+- **LIN-61** — *answered:* recording a divorce is admin-only, by decision rather than by accident
+
+**One correction to the survey above.** Candidate 04 cites the `RelativeDirection` / `'sibling'` mismatch as a defect. On closer reading it isn't: `create_relative_secure` genuinely handles `sibling` (`20260406120000_lin22_first_name.sql:161`, with its own "target has no parents to branch from" guard). The incomplete thing is the TypeScript type at `graph.ts:30`, which omits it — `treeRecord.ts:35` widens it inline with `RelativeDirection | 'sibling'`. The tidier fix is to add `'sibling'` to the type itself. Minor, and folded into candidate 04's scope.


### PR DESCRIPTION
`ad3ec13` re-authored the LIN-53 docs instead of merging the existing ones. Docs-only, no code.

## What it added that's kept

The ADR now documents the **real implementation** — exact transport routing per operation, `createTreeRecord(identity, config)`, `relativeToKinshipLink()`, and `'unknown'` on the error discriminant. None of that existed when the ADR was drafted. All retained.

## What was dropped, and restored here

**The survey went 233 → 48 lines.** Main's version is a LIN-53 retrospective; everything about candidates 02–06 was gone — the ordering graph, per-candidate evidence, the staleness warning, the "deliberately not candidates" section. **LIN-54, 55, 56, 57 and 58 all link to this file as their evidence.** Restores the full survey and folds the LIN-53 retrospective in as a closing Outcome section.

**ADR-0003 lost four things:**
- The division-of-authorization-labour section, and specifically *"the module's check is a UI affordance, not a security boundary"* — the line most likely to be misread, since main only said RLS gaps "remain documented under LIN-59"
- All four considered-and-rejected alternatives, including why the links array is deliberately not passed in
- **The LIN-61 decision** — recording a divorce is admin-only, by decision rather than by accident. The word "admin-only" appeared zero times. Restored with the rationale, because `marriage` is unrestricted for the same users and this will be re-proposed
- The note that the rule isn't DB-enforced (`links_insert_1degree_or_admin` treats `is_admin()` as one disjunct of three)

**`CONTEXT.md`'s Tree Record named a source file.** `"The single source of truth and deep write module (src/lib/treeRecord.ts)"` — a path in a glossary. It also lost the persisted-vs-rendered distinction that LIN-58 depends on. Restored. Main's good addition to Kinship Link ("Expressed as an absolute edge between two IDs") is kept.

**`docs/agents/issue-tracker.md` was omitted entirely** — so the Osra project convention still isn't on main, and the next agent files issues loose in the team.

## One correction to the survey itself

Candidate 04 flagged the `RelativeDirection` / `'sibling'` mismatch as a defect. It isn't — `create_relative_secure` genuinely handles `sibling` (`20260406120000_lin22_first_name.sql:161`, with its own guard). The incomplete thing is the TypeScript type at `graph.ts:30`; `treeRecord.ts:35` widens it inline. Noted in the file and folded into candidate 04's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)