### PR TITLE
fix(security): prevent invite token enumeration and enforce server-side expiry (LIN-60)

### DIFF
--- a/src/components/modals/BulkInviteModal.tsx
+++ b/src/components/modals/BulkInviteModal.tsx
@@ -143,7 +143,8 @@ export default function BulkInviteModal({
     if (!relativesData.length) return;
     const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
     const supabaseKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
-    const authToken = session?.access_token || supabaseKey;
+    const authToken = session?.access_token;
+    if (!authToken) return;
 
     try {
       const nodeIds = relativesData.map(r => r.node.id).join(',');
@@ -190,7 +191,7 @@ export default function BulkInviteModal({
     try {
       const selectedNodeIds = selected.map(r => r.node.id).join(',');
       const nowIso = new Date().toISOString();
-      await fetch(
+      const patchRes = await fetch(
         `${supabaseUrl}/rest/v1/node_invites?node_id=in.(${selectedNodeIds})&claimed_by_user_id=is.null`,
         {
           method: 'PATCH',
@@ -205,6 +206,9 @@ export default function BulkInviteModal({
           }),
         }
       );
+      if (!patchRes.ok) {
+        console.warn(`[BulkInvite] Failed to invalidate existing invites (status ${patchRes.status})`);
+      }
     } catch (err) {
       console.error('[BulkInvite] Failed to invalidate existing invites:', err);
       // Continue anyway; failure to invalidate should not block new invites

--- a/src/lib/permissions.test.ts
+++ b/src/lib/permissions.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { canEdit } from './permissions';
+import { canEdit, canManageInvites } from './permissions';
 import { FamilyLink } from '../types/graph';
 
 describe('permissions for Action Handles', () => {
@@ -36,3 +36,35 @@ describe('permissions for Action Handles', () => {
     expect(canEdit('unrelated-child', 'user-node', false, links)).toBe(false);
   });
 });
+
+describe('permissions for managing invites (LIN-60)', () => {
+  const links: FamilyLink[] = [
+    { source: 'user-node', target: 'child-1', type: 'parent' },
+    { source: 'parent-1', target: 'user-node', type: 'parent' },
+    { source: 'user-node', target: 'spouse-1', type: 'marriage' },
+    { source: 'parent-1', target: 'sibling-1', type: 'parent' },
+    { source: 'unrelated-1', target: 'unrelated-child', type: 'parent' },
+  ];
+
+  it('allows admin to manage invites for any node even without a bound node', () => {
+    expect(canManageInvites('unrelated-1', null, true, links)).toBe(true);
+    expect(canManageInvites('child-1', null, true, links)).toBe(true);
+  });
+
+  it('allows bound user to manage invites for 1-degree relatives', () => {
+    expect(canManageInvites('child-1', 'user-node', false, links)).toBe(true);
+    expect(canManageInvites('parent-1', 'user-node', false, links)).toBe(true);
+    expect(canManageInvites('spouse-1', 'user-node', false, links)).toBe(true);
+    expect(canManageInvites('sibling-1', 'user-node', false, links)).toBe(true);
+  });
+
+  it('denies bound user from managing invites outside 1-degree network', () => {
+    expect(canManageInvites('unrelated-1', 'user-node', false, links)).toBe(false);
+    expect(canManageInvites('unrelated-child', 'user-node', false, links)).toBe(false);
+  });
+
+  it('denies unbound non-admin from managing invites', () => {
+    expect(canManageInvites('child-1', null, false, links)).toBe(false);
+  });
+});
+

--- a/src/pages/InvitePage.tsx
+++ b/src/pages/InvitePage.tsx
@@ -191,6 +191,10 @@ export default function InvitePage() {
             setInviteStatus('claimed');
             setErrorMessage('This invite has already been claimed.');
             break;
+          case 'expired_invite':
+            setInviteStatus('expired');
+            setErrorMessage('This invite has expired.');
+            break;
           case 'already_bound':
             setErrorMessage('You are already bound to a node in the family tree.');
             break;

--- a/supabase/migrations/20260817130000_lin60_secure_node_invites.sql
+++ b/supabase/migrations/20260817130000_lin60_secure_node_invites.sql
@@ -1,0 +1,110 @@
+-- LIN-60: Security fixes for node invites:
+-- 1. Restrict node_invites SELECT from public to authenticated users who can manage invites for the node (or admin).
+-- 2. Add node_invites UPDATE policy so bulk invite expiry (invalidation) works.
+-- 3. Revoke direct table privileges on node_invites from anon role.
+-- 4. Fix can_manage_invites_for_node so admins without a bound node_id can manage invites.
+-- 5. Enforce expires_at check in claim_invite_secure on the server.
+
+-- 1. Helper function: Allow admins or 1-degree connected users to manage invites
+CREATE OR REPLACE FUNCTION public.can_manage_invites_for_node(p_node_id uuid)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF auth.uid() IS NULL THEN RETURN FALSE; END IF;
+  IF (SELECT is_admin()) THEN RETURN TRUE; END IF;
+  RETURN is_within_1_degree(p_node_id);
+END;
+$$;
+
+ALTER FUNCTION public.can_manage_invites_for_node(uuid) OWNER TO postgres;
+
+-- 2. RLS policies on public.node_invites
+DROP POLICY IF EXISTS node_invites_select ON public.node_invites;
+DROP POLICY IF EXISTS node_invites_select_1degree_or_admin ON public.node_invites;
+
+CREATE POLICY node_invites_select_1degree_or_admin ON public.node_invites
+  FOR SELECT TO authenticated
+  USING (can_manage_invites_for_node(node_id));
+
+DROP POLICY IF EXISTS node_invites_update_1degree ON public.node_invites;
+
+CREATE POLICY node_invites_update_1degree ON public.node_invites
+  FOR UPDATE TO authenticated
+  USING (can_manage_invites_for_node(node_id))
+  WITH CHECK (can_manage_invites_for_node(node_id));
+
+-- 3. Revoke anon table privileges on node_invites (anon access should go exclusively through get_invite_by_token RPC)
+REVOKE ALL ON TABLE public.node_invites FROM anon;
+
+-- 4. Clean up legacy single-arg overload if present
+DROP FUNCTION IF EXISTS public.claim_invite_secure(text);
+
+-- 5. claim_invite_secure: Enforce token expiration on the server
+CREATE OR REPLACE FUNCTION public.claim_invite_secure(invite_token text, claiming_user_id uuid)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  invite_record public.node_invites%ROWTYPE;
+  existing_user_node_id UUID;
+BEGIN
+  IF auth.uid() IS NULL THEN
+    RETURN json_build_object('success', false, 'error', 'unauthorized', 'message', 'You must be signed in');
+  END IF;
+
+  IF auth.uid() != claiming_user_id THEN
+    RETURN json_build_object('success', false, 'error', 'unauthorized', 'message', 'You can only claim an invite for yourself');
+  END IF;
+
+  SELECT * INTO invite_record FROM public.node_invites WHERE token = invite_token;
+  IF NOT FOUND THEN
+    RETURN json_build_object('success', false, 'error', 'invalid_invite', 'message', 'This invite link is not valid');
+  END IF;
+
+  IF invite_record.claimed_by_user_id IS NOT NULL THEN
+    RETURN json_build_object('success', false, 'error', 'already_claimed', 'message', 'This invite has already been claimed');
+  END IF;
+
+  IF invite_record.expires_at IS NOT NULL AND invite_record.expires_at < now() THEN
+    RETURN json_build_object('success', false, 'error', 'expired_invite', 'message', 'This invite link has expired');
+  END IF;
+
+  SELECT node_id INTO existing_user_node_id FROM public.users WHERE id = claiming_user_id;
+  IF existing_user_node_id IS NOT NULL THEN
+    RETURN json_build_object('success', false, 'error', 'already_bound', 'message', 'You are already bound to a node in the family tree');
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM auth.users WHERE id = claiming_user_id) THEN
+    RETURN json_build_object('success', false, 'error', 'auth_not_found', 'message', 'Unable to retrieve profile');
+  END IF;
+
+  INSERT INTO public.users (id, node_id, role, full_name, email)
+  SELECT
+    claiming_user_id,
+    invite_record.node_id,
+    'user',
+    COALESCE(au.raw_user_meta_data->>'full_name', au.raw_user_meta_data->>'name'),
+    au.email
+  FROM auth.users au
+  WHERE au.id = claiming_user_id
+  ON CONFLICT (id) DO UPDATE SET
+    node_id = EXCLUDED.node_id,
+    full_name = COALESCE(EXCLUDED.full_name, public.users.full_name),
+    email = COALESCE(EXCLUDED.email, public.users.email);
+
+  UPDATE public.node_invites SET claimed_by_user_id = claiming_user_id WHERE token = invite_token;
+
+  RETURN json_build_object('success', true, 'node_id', invite_record.node_id);
+END;
+$$;
+
+ALTER FUNCTION public.claim_invite_secure(text, uuid) OWNER TO postgres;
+
+-- 6. Ensure explicit execute grants
+GRANT EXECUTE ON FUNCTION public.get_invite_by_token(text) TO anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.claim_invite_secure(text, uuid) TO authenticated, service_role;

--- a/supabase/reference/policies.sql
+++ b/supabase/reference/policies.sql
@@ -88,14 +88,22 @@ CREATE POLICY links_delete_admin_only ON public.links
 -- ============================================================================
 -- NODE_INVITES
 -- ============================================================================
-CREATE POLICY node_invites_select ON public.node_invites
-  FOR SELECT TO public
-  USING (true);
+-- LIN-60: Scoped to authenticated users who can manage the node (or admin)
+CREATE POLICY node_invites_select_1degree_or_admin ON public.node_invites
+  FOR SELECT TO authenticated
+  USING (can_manage_invites_for_node(node_id));
 
 CREATE POLICY node_invites_insert_1degree ON public.node_invites
   FOR INSERT TO authenticated
   WITH CHECK (can_manage_invites_for_node(node_id));
 
+-- LIN-60: Allows bulk invalidation of prior unclaimed invites
+CREATE POLICY node_invites_update_1degree ON public.node_invites
+  FOR UPDATE TO authenticated
+  USING (can_manage_invites_for_node(node_id))
+  WITH CHECK (can_manage_invites_for_node(node_id));
+
 CREATE POLICY node_invites_delete_1degree ON public.node_invites
   FOR DELETE TO authenticated
   USING (can_manage_invites_for_node(node_id));
+


### PR DESCRIPTION
Closes LIN-60

### Summary of Changes
- **Secured `public.node_invites` table**:
  - Replaced public `node_invites_select` policy with `node_invites_select_1degree_or_admin` (`TO authenticated USING (can_manage_invites_for_node(node_id))`).
  - Added `node_invites_update_1degree` policy (`FOR UPDATE TO authenticated`) so bulk invalidation (`PATCH /rest/v1/node_invites`) succeeds.
  - Revoked direct table privileges from `anon` (`REVOKE ALL ON TABLE public.node_invites FROM anon;`).
  - Token lookup remains exclusively via `get_invite_by_token` RPC.
- **Enforced server-side token expiry**:
  - Added `expires_at < now()` validation inside `claim_invite_secure` returning `{ success: false, error: 'expired_invite' }`.
  - Updated `InvitePage.tsx` to handle `expired_invite` error state.
- **Fixed unbound admin invite management**:
  - Updated `can_manage_invites_for_node` to check `is_admin()` prior to requiring a bound `user_node_id`.
- **Reference & Tests**:
  - Updated `supabase/reference/policies.sql`.
  - Added unit tests for `canManageInvites` in `src/lib/permissions.test.ts`.